### PR TITLE
Phase 2 · P1 skills (T-README-04~08)

### DIFF
--- a/docs/skills/brainstorm.md
+++ b/docs/skills/brainstorm.md
@@ -1,0 +1,42 @@
+# `/brainstorm`
+
+> Clarify a vague feature request into a concrete requirements doc through a 3-lens pass, then stop — do not plan.
+
+## Paradigm
+
+`/brainstorm` exists because the most expensive mistake in a Claude Code session is committing to a plan built on an ambiguous prompt. Every lens in the skill interrogates the prompt from a different direction, and the skill refuses to emit a requirements doc until all three have run. The output is deliberately not a plan: it is a `*-requirements.md` file that `/plan` can consume. Separating "what are we building?" from "how do we build it?" is the whole reason `/brainstorm` is its own skill.
+
+## Judgment
+
+Input is free-form user intent (English or Korean). Output is a single file at `.claude/plans/YYYY-MM-DD-{slug}-requirements.md` with a fixed frontmatter schema (`slug`, `type: requirements`, `date`, `source_skill: clarify:vague`, `audience`) and body sections (`Goal` · `Scope {Included / Excluded}` · `Constraints` · `Success Criteria` · `Non-goals` · `Artifacts` · `Open Questions`).
+
+The skill blocks on three gates:
+
+1. **Each lens produces at least one resolved ambiguity.** If a lens cannot find anything to clarify, it explicitly records "no ambiguity on this lens"; silence is not allowed.
+2. **Open Questions list is non-empty.** Every requirements doc ships with the handoff to `/plan` that names the decisions the plan phase must make.
+3. **Goal line is ≤ 1 sentence.** Enforces a single testable outcome, which is what `/plan`'s Ambiguity Score Gate reads.
+
+## Design Choices
+
+- **3 lenses, not 1.** One lens (pure "vague → concrete") misses strategic blind spots and form-level reframings. Three lenses run cheap and cover more surface than a deeper single pass.
+  - `vague` — turns imprecise wording into testable assertions.
+  - `unknown` — applies the Known/Unknown 4-quadrant framework to surface hidden assumptions.
+  - `metamedium` — asks whether the form (the *how*) should change, not just the content (the *what*).
+- **Phases are 1 → 4, not parallel.** Phase 1 collects the raw request, Phase 2 runs lenses, Phase 3 drafts the doc, Phase 4 gates on Open Questions. Parallelising the lenses was tried and produced merge conflicts in the draft; serial is simpler.
+- **No plan emission.** The skill deliberately stops at `*-requirements.md`. Attempting to write `plan.md` from `/brainstorm` would collapse the Plan-axis gate from `/plan`.
+- **Korean + English trigger parity.** Both "브레인스토밍" and "spec this out" fire the same skill with the same schema. See [`../thresholds.md` §4](../thresholds.md#4-description-trigger-accuracy--δko--en--5-) for the bilingual accuracy bound.
+- **Audience is declared.** The frontmatter `audience` field (e.g. `plugin_users_developer_primary`) is what `/plan` uses to scope Success Criteria.
+
+## Thresholds
+
+All bilingual and trigger-accuracy numbers live in [`../thresholds.md`](../thresholds.md):
+
+- Description trigger Δ ≤ 5 %pp — [§4](../thresholds.md#4-description-trigger-accuracy--δko--en--5-).
+- `validate_prompt` fire/response rates — [§3](../thresholds.md#3-validate_prompt--fire_rate--099-response_rate--090) (applies to all skills including `/brainstorm`).
+
+## References
+
+- Upstream `p4cn` (plugins-for-claude-natives) — clarify 3-lens pattern and the `requirements.md` schema.
+- Upstream `ouroboros` — Ambiguity Gate concept that `/plan` reads from our Open Questions.
+- [`../axes.md`](../axes.md) — `/brainstorm`'s axis matrix row (Context ON, Plan/Execute/Verify OFF, Improve log-only).
+- [`../../skills/brainstorm/SKILL.md`](../../skills/brainstorm/SKILL.md) — the SKILL contract (frontmatter + hooks).

--- a/docs/skills/compound.md
+++ b/docs/skills/compound.md
@@ -1,0 +1,50 @@
+# `/compound`
+
+> Promote user-approved learnings into durable memory through a 6-step gate, 3 triggers, and a 5-dimensional overlap check.
+
+## Paradigm
+
+Automatic memory writes are the failure mode `/compound` is designed to prevent. Every other plugin in the neighbourhood writes memory first and asks forgiveness later; `/compound` inverts the default — nothing reaches `.claude/memory/` without an explicit user approval. The three triggers decide *when* to ask, the 5-dimensional overlap decides *whether to ask at all*, and the 6-step gate decides *how the user answers*. Together they turn memory from a passive accumulator into a curated artifact.
+
+## Judgment
+
+Input: a candidate promotion event (one of three triggers). Output: zero, one, or several files written to `.claude/memory/{tacit,corrections,preferences}/*.md`, each containing only fields the user accepted.
+
+The three triggers:
+
+1. **`pattern_repeat`** — the same correction appears `≥ 2` times within a session window. Fires from the `Stop` hook.
+2. **`user_correction`** — the user explicitly negates a previous action ("no, stop doing X"). Fires from the `PreToolUse` hook.
+3. **`session_wrap`** — `/session-wrap` or session end; batches all pending candidates into a single prompt.
+
+Decision flow for a candidate:
+
+1. Compute 5-dimensional overlap against existing entries. If overlap `≥ 0.80` with any entry, the candidate is a duplicate — skip.
+2. Oscillation guard: if the candidate overlaps `Gen N-2` at `≥ 0.80`, abort the promotion loop; a ping-pong has been detected.
+3. Present the 6-step gate to the user (see below). Only entries approved at every step are written.
+
+## Design Choices
+
+- **3 triggers, not "write on every correction."** A single trigger (only corrections) would miss pattern-level signals; a single trigger (only session-wrap) would miss hot-in-the-moment context. Three triggers cover repeat, in-flight, and batched without overlapping by construction.
+- **Batching in the `Stop` hook.** The 3rd trigger (`session_wrap`) exists specifically so the user is not interrupted for each candidate mid-session. All held candidates are presented once.
+- **Auto-disable after 3 consecutive rejections.** If a detector produces 3 rejected candidates in a row, it is suppressed for 7 days. Noisy detectors pay the cost of being noisy.
+- **6-step promotion gate.** The prompt walks the user through `summary → context → evidence → proposed entry → target path → final y/N/e/s`. Each step can be edited (`e`) or skipped (`s`); only the final step writes. Bundling all six into one prompt was tried and produced higher false-positive rates because users accepted bundled entries they would have rejected individually.
+- **5-dimensional overlap, not token similarity.** Token cosine similarity misses semantic duplicates across rephrasings. Scoring `problem · cause · solution · files · prevention` independently captures the axes that matter for a correction.
+- **Oscillation guard looks `N-2` back.** `N-1` is too tight (legitimate incremental improvement triggers false oscillation) and `N-3` is too loose (a two-step ping-pong cycles under the detector). `N-2` is the minimum window that catches the `A → B → A` case.
+- **Three target directories, not one.** `tacit/` vs `corrections/` vs `preferences/` keeps retrieval scoped — a future `/brainstorm` can load corrections without polluting context with preferences.
+
+## Thresholds
+
+All numeric values live in [`../thresholds.md`](../thresholds.md):
+
+- Promotion-gate false-positive ≤ `0.20` — [§5](../thresholds.md#5-promotion-gate-false-positive-rate---20-).
+- 5-dimensional overlap weights `problem 0.30 · cause 0.20 · solution 0.20 · files 0.15 · prevention 0.15` (sum = 1.00) — [§7](../thresholds.md#7-5-dimensional-overlap-weights).
+- Oscillation guard `overlap ≥ 0.80` within `Gen N-2` — [§8](../thresholds.md#8-oscillation-guard--overlap--080-within-gen-n-2).
+- Auto-disable cadence (3 rejections / 7 days) — design convention, tracked in this file.
+
+## References
+
+- Upstream `compound-engineering-plugin` — 5-dimensional overlap scoring, Auto Memory conventions, persistence discipline.
+- Upstream `p4cn` — `session-wrap` 2-phase pipeline that drives the 3rd trigger.
+- [`../axes.md`](../axes.md) — `/compound`'s axis matrix row (Context ON, Execute ON, Improve ON).
+- [`../faq.md`](../faq.md) — Q4 (gate annoyance), Q5 (`/orchestrate` vs manual chaining).
+- [`../../skills/compound/SKILL.md`](../../skills/compound/SKILL.md) — the SKILL contract.

--- a/docs/skills/orchestrate.md
+++ b/docs/skills/orchestrate.md
@@ -1,0 +1,62 @@
+# `/orchestrate` *(Stretch)*
+
+> Chain `/brainstorm → /plan → /verify → /compound` through six disk checkpoints, SHA256-pinned, crash-safe on resume.
+
+## Paradigm
+
+`/orchestrate` is the only skill that lights up all six axes at once. Every other skill owns a subset of the pipeline; `/orchestrate` owns the pipeline itself. The design tension it resolves is the gap between "I want the end-to-end run" and "I do not want to rerun the first three axes because the fourth crashed." Disk checkpoints are the cheapest mechanism we found that preserves both properties — the run goes fast when nothing breaks, and resumes cleanly from the last disk write when something does.
+
+## Judgment
+
+Input: a topic prompt (English or Korean). Output: a six-file checkpoint trail plus the final artifacts from each axis.
+
+Sequential phases and checkpoints:
+
+| CP | Phase | Checkpoint contents |
+|----|-------|---------------------|
+| **CP-0** | `/brainstorm` invocation | Input prompt + resolved ambiguities |
+| **CP-1** | `/plan` emission | Hybrid Markdown + YAML plan file |
+| **CP-2** | `/verify` verdict | `qa-judge` JSON report |
+| **CP-3** | `/compound` gate result | Approved / rejected candidates |
+| **CP-4** | Artifact link bundle | All file paths + SHA256s |
+| **CP-5** | `experiment-log.yaml` commit | Git commit recording the full run |
+
+Each checkpoint file lives under `.claude/state/orchestrate/<run-id>/cp-N.json` with its own SHA256 recorded in `cp-N.json.sha256`. On re-invocation, `/orchestrate` reads the latest valid CP file and resumes from the next phase. The SHA pin is what turns "resume from disk" from a liability into a guarantee — if any checkpoint has been tampered with, resume refuses and the run restarts from CP-0.
+
+### Allowed `dispatch × work × verify` combinations
+
+`/orchestrate` accepts exactly three combinations of dispatch strategy × worker shape × verify placement:
+
+1. **sequential × single × end** — one worker, one axis at a time, verify at the very end. The default.
+2. **sequential × single × per-axis** — one worker, one axis at a time, verify after *each* axis. Costs more but tightens the feedback loop.
+3. **parallel-tasks × many × per-axis** — parallel workers on independent tasks within an axis, verify gated per-axis.
+
+Other combinations (e.g. parallel × many × end-only) are rejected — they remove the axis-level blast radius control the harness is designed to enforce.
+
+## Design Choices
+
+- **4 axes in order, not in parallel.** Brainstorm must resolve before Plan; Plan must exist before Verify; Verify must pass before Compound. The sequential dependency is structural, not a performance choice.
+- **Disk checkpoints, not in-memory state.** The whole point is surviving a crash. Anything short of disk is lost when the session dies.
+- **SHA256 pin per checkpoint.** Without the pin, a tampered CP file would let resume start from a state that never existed. The pin turns resume into a verified operation.
+- **`CP-4` bundles artifact paths, not the artifacts themselves.** Duplicating artifacts into the checkpoint trail bloats the run directory and guarantees drift. Paths + SHAs let the resume validate without copying.
+- **`CP-5` is a git commit, not a file.** The final checkpoint has to be durable against workspace rm. A commit is the strongest portable durability boundary on a local machine.
+- **Three `dispatch × work × verify` combinations, not arbitrary.** The restricted set is enumerable, reviewable, and safe. Any combination that removes per-axis verification defeats the harness.
+- **Re-invocation is idempotent per checkpoint.** Running `/orchestrate` twice at CP-3 does not re-run CP-0..CP-2; it reads their outputs and resumes. Idempotency is the property that makes resume trustworthy.
+
+## Thresholds
+
+All numeric values live in [`../thresholds.md`](../thresholds.md):
+
+- `qa-judge` verdict bands applied per axis — [§1](../thresholds.md#1-qa-judge-verdict-bands--promote--080-retry-040080-reject--040).
+- Ralph Loop retry cap `3` inherited from `/verify` — [§6](../thresholds.md#6-ralph-loop-retry-cap--3).
+- Oscillation guard (shared with `/compound`) — [§8](../thresholds.md#8-oscillation-guard--overlap--080-within-gen-n-2).
+- SHA256 integrity per checkpoint — design convention, tracked here.
+
+## References
+
+- Upstream `ouroboros` — checkpoint + resume convention adapted for slash-command runs.
+- Upstream `superpowers` — `SessionStart` hook and axis-scoped hook design.
+- Upstream `agent-council` — marketplace minimal structure, Wait cursor UX during long runs.
+- [`../axes.md`](../axes.md) — all six axes (this is the only row where every cell is ON).
+- [`../faq.md`](../faq.md) — Q5 (`/orchestrate` vs manual chaining).
+- [`../../skills/orchestrate/SKILL.md`](../../skills/orchestrate/SKILL.md) — the SKILL contract.

--- a/docs/skills/plan.md
+++ b/docs/skills/plan.md
@@ -1,0 +1,45 @@
+# `/plan`
+
+> Turn a requirements doc into a hybrid Markdown + YAML plan that both humans and `qa-judge` can parse.
+
+## Paradigm
+
+`/plan` takes a single input (`*-requirements.md` from `/brainstorm`) and produces a single file that serves two readers at once: a human reviewer who reads the Markdown body, and the `qa-judge` Evaluator that reads the YAML frontmatter. The dual-reader constraint is the whole point — a plan that only humans can parse cannot be verified, and a plan that only machines can parse cannot be reviewed. The hybrid format is the contract that keeps both honest.
+
+## Judgment
+
+Input is a requirements doc path; output is `.claude/plans/YYYY-MM-DD-{slug}-plan.md` containing:
+
+- **YAML frontmatter** — `goal`, `slug`, `date`, `parent_seed_id`, `source_requirements`, `ambiguity_verdict`, `ambiguity_score`, `constraints`, `acceptance_criteria {hard, stretch}`, `evaluation_principles [{name, weight, description, metric}]`, `exit_conditions {success, failure, timeout}`.
+- **Markdown body** — `Ambiguity Score Gate`, `Decisions`, `Tasks` (with dependency graph), `Gaps`, `Exit Conditions`, `Next Steps`.
+
+The skill blocks on:
+
+1. **Ambiguity Score Gate.** If `ambiguity_score > 0.20`, the skill refuses and redirects back to `/brainstorm`. The gate is computed from the number of unresolved Open Questions divided by a normalising constant.
+2. **Evaluation principles sum to `1.00`.** Any weight set that does not sum cleanly is rejected before emission.
+3. **Every Hard AC maps to at least one task.** An AC with no task is an AC that cannot pass; the skill refuses to emit.
+
+## Design Choices
+
+- **Markdown + YAML hybrid, not two files.** Two files (a `plan.md` and a `plan.yaml`) diverge in practice — someone edits one and forgets the other. A single file with frontmatter is self-consistent by construction.
+- **Ambiguity Score Gate at `0.20`.** Below `0.20`, open questions are small enough that `/plan` can decide them inline (see the `Decisions` table every plan emits). Above `0.20`, the honest action is to go back to `/brainstorm`. The gate is a boundary, not a heuristic.
+- **Weighted `evaluation_principles`, sum = 1.00.** Weights force the plan author to declare tradeoffs explicitly. `qa-judge` scores the artifact by the same weights, so the plan and the verification are measuring the same thing.
+- **`exit_conditions` has three fields, not one.** `success`, `failure`, and `timeout` are distinct — success criteria are what we are trying to achieve, failure criteria are what forces a stop-and-rework, and timeout is the budget. Collapsing them loses the "we ran out of time, so ship P0 only" branch.
+- **Task dependency graph is explicit.** Each task lists `depends_on: [task_ids]`. A graph is parseable; prose is not. This is what lets `/orchestrate` parallelise the independent branches.
+- **No plan amends the requirements doc.** The requirements doc is immutable once `/plan` consumes it; drift goes into the `Decisions` table with a rationale.
+
+## Thresholds
+
+All quantitative values live in [`../thresholds.md`](../thresholds.md):
+
+- Ambiguity Score Gate `0.20` — design-inferred boundary (see §2 derivation of sample sizes for the family of `1/√n` readability bounds).
+- `qa-judge` verdict bands `0.80 / 0.40` that `/plan` outputs are scored against — [§1](../thresholds.md#1-qa-judge-verdict-bands--promote--080-retry-040080-reject--040).
+- `validate_prompt` fire/response rates — [§3](../thresholds.md#3-validate_prompt--fire_rate--099-response_rate--090).
+
+## References
+
+- Upstream `ouroboros` — Seed YAML schema, Ambiguity Gate, `evaluation_principles` weighting.
+- Upstream `hoyeon` — `validate_prompt` hook pattern (used by `/plan` to enforce the AC-to-task mapping).
+- [`../axes.md`](../axes.md) — `/plan`'s axis matrix row (all six axes ON except Improve).
+- [`../../skills/plan/SKILL.md`](../../skills/plan/SKILL.md) — the SKILL contract.
+- Internal: final-spec v3.1 §2.2 Decision #10 for the Markdown + YAML choice.

--- a/docs/skills/verify.md
+++ b/docs/skills/verify.md
@@ -1,0 +1,50 @@
+# `/verify`
+
+> Score an artifact with `qa-judge`, retry through Ralph Loop, and fall through to manual review when the cap hits.
+
+## Paradigm
+
+Verify is the one axis whose absence looks identical to a pass. `/verify` exists so that absence becomes impossible: it produces a numeric verdict (`qa-judge` score + dimensions) that any other skill (`/plan`, `/compound`, `/orchestrate`) can read without re-interpreting the artifact. The retry loop (Ralph Loop) and the fresh-context separation are there to make the verdict *credible*, not just present. If `/verify` were single-pass and reused the author's context, the verdict would be a self-review.
+
+## Judgment
+
+Input: an artifact path plus optional `--axis N` scope. Output: a `qa-judge` JSON report with `{score, verdict, dimensions, differences, suggestions}`.
+
+Decision logic:
+
+1. Run `qa-judge` in a **fresh Claude Code context** (no author turns loaded). This is what prevents the Evaluator from inheriting the author's blind spots.
+2. Read `score` and place it into one of three bands:
+   - `score ≥ 0.80` → `promote` (accept).
+   - `0.40 ≤ score < 0.80` → `retry` (Ralph Loop with up to 3 attempts).
+   - `score ≤ 0.40` → `reject` (return to author).
+3. On `retry`, run the **3-stage Evaluator**: (a) diff the artifact against the acceptance criteria, (b) propose minimal edits, (c) re-score. If the post-edit score crosses into `promote`, accept; otherwise decrement the retry counter.
+4. When the retry counter reaches zero, emit `verdict: manual_review` rather than forcing another loop. The cap is a circuit breaker, not a target.
+
+`--axis N` narrows `qa-judge` to a single axis rubric (e.g. `--axis 5` runs Verify-only on a plan). `--skip-axis 5 --acknowledge-risk` is the only way to bypass `/verify` at the pipeline level; see [`../axes.md`](../axes.md#axis-5-is-different---skip-axis-5-requires---acknowledge-risk).
+
+## Design Choices
+
+- **Fresh context, not a persistent one.** A persistent Evaluator converges on the author's reasoning after a few rounds. A fresh context forces the Evaluator to re-derive its verdict from the artifact alone, which is what we want.
+- **3 bands, not 2.** A binary `pass / fail` throws away the signal that an artifact is "almost good enough, try once more." The `retry` band is where Ralph Loop adds its value.
+- **Ralph Loop, not an ad-hoc retry.** Ralph Loop is the `ouroboros` convention with a capped counter and a structured critic. Ad-hoc retries in the author's context would be self-review in a trench coat.
+- **3-stage Evaluator inside the retry.** Splitting "diff → propose → re-score" keeps each stage simple. A one-shot "rewrite and re-score" was tried and tended to rewrite the acceptance criteria along with the artifact.
+- **`qa-judge` emits structured JSON, not prose.** Consumers (`/compound`, `/orchestrate`, the skip log) need a parseable verdict. Prose-only reports are not parseable.
+- **Fall-through to `manual_review` on cap.** A silent loop past the cap is worse than a loud escalation. The cap is the hand-off to a human, not a failure of the skill.
+
+## Thresholds
+
+All numeric values live in [`../thresholds.md`](../thresholds.md):
+
+- Verdict bands `promote ≥ 0.80 / retry 0.40–0.80 / reject ≤ 0.40` — [§1](../thresholds.md#1-qa-judge-verdict-bands--promote--080-retry-040080-reject--040).
+- Ralph Loop retry cap `3` — [§6](../thresholds.md#6-ralph-loop-retry-cap--3).
+- `validate_prompt` fire/response rates `≥ 0.99 / 0.90` — [§3](../thresholds.md#3-validate_prompt--fire_rate--099-response_rate--090).
+- KU-0 histogram behind the bands — [§1](../thresholds.md#1-qa-judge-verdict-bands--promote--080-retry-040080-reject--040) cites `p25 = 0.50`, `p75 = 0.86`.
+
+## References
+
+- Upstream `ouroboros` — `qa-judge` JSON schema, Ralph Loop convention, retry cap.
+- Upstream `superpowers` (obra/superpowers) — `HARD-GATE` tag pattern and the 3-stage Evaluator.
+- Upstream `hoyeon` — 6-agent verify stack referenced by the 3-stage Evaluator's diff-and-propose split.
+- [`../axes.md`](../axes.md) — Axis 5 rationale and the `--acknowledge-risk` contract.
+- [`../faq.md`](../faq.md) — Q3 (Ralph Loop infinite loop?), Q9 (`--acknowledge-risk`).
+- [`../../skills/verify/SKILL.md`](../../skills/verify/SKILL.md) — the SKILL contract.


### PR DESCRIPTION
## Summary
5 skill docs in `docs/skills/` following the 5-section template (Paradigm · Judgment · Design Choices · Thresholds · References):
- T-README-04: `brainstorm.md` — 3-lens paradigm, Phase 1~4, requirements.md schema
- T-README-05: `plan.md` — Markdown+YAML hybrid rationale, Ambiguity Gate 0.20, weights sum 1.00
- T-README-06: `verify.md` — qa-judge + Ralph Loop + 3-stage Evaluator + fresh context
- T-README-07: `compound.md` — 3 triggers, 6-step gate, 5-D overlap (numbers linked only)
- T-README-08: `orchestrate.md` — 4-axis CP-0~CP-5, dispatch×work×verify allowed triples

## AC
- AC-H2 PASS (5/5 template compliance)
- AC-H1 progresses to 8/8 files after merge
- All files ≤ 200 lines; all numbers link to `docs/thresholds.md` (no duplication)

## Next
Phase 3 (README polish) aligns README.md + README.ko.md to new docs/.