### PR TITLE
Phase 3 · README polish (T-README-09·10)

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -43,24 +43,19 @@ git clone https://github.com/<owner>/crucible.git ~/.claude/plugins/crucible
 
 - `/brainstorm` — 3-lens(vague · unknown · metamedium) clarify 패스로 진행하는 요구사항 브레인스토밍. `.claude/plans/YYYY-MM-DD-{slug}-requirements.md`로 저장.
 - `/plan` — 요구사항 문서에서 Markdown + YAML frontmatter 하이브리드 플랜 생성. acceptance criteria · evaluation principles(가중치) · exit conditions 포함.
-- `/verify` — `qa-judge`로 산출물 채점 (promote ≥ 0.80, retry 0.40–0.80, reject ≤ 0.40) + Ralph Loop 재시도 + Charter Preflight.
+- `/verify` — `qa-judge`로 산출물 채점 + Ralph Loop 재시도 + Charter Preflight.
 - `/compound` — 반복 패턴·유저 정정·`/session-wrap` 트리거를 위한 승격 게이트. 유저 승인된 후보만 `.claude/memory/`에 저장.
 - `/orchestrate` *(Stretch)* — 위 4 스킬을 end-to-end 파이프라인으로 연결. CP-0~CP-5 디스크 체크포인트로 크래시 안전.
+
+**상세** → [`docs/skills/`](./docs/skills/) (스킬별 Paradigm · Judgment · Design Choices).
 
 ---
 
 ## 6축 하네스 (6-Axis Harness)
 
-| # | 축 | 강제 사항 |
-|---|----|----------|
-| 1 | **Structure** | 플러그인 레이아웃, manifest 무결성, 슬래시 커맨드 등록 |
-| 2 | **Context** | `SessionStart` 훅 + `using-harness` 가이드 + `MEMORY.md` 주입 |
-| 3 | **Plan** | 사람·Evaluator가 함께 파싱하는 Markdown + YAML 하이브리드 산출물 |
-| 4 | **Execute** | 스코프 스킬, 훅 검증 프롬프트, SHA256 페이로드 고정 |
-| 5 | **Verify** | `qa-judge` · Ralph Loop · 3-stage Evaluator · grey-zone fallback |
-| 6 | **Improve** | `/compound` 승격 게이트 → `tacit/`, `corrections/`, `preferences/` 메모리 |
+모든 산출물은 6축 게이트(**Structure · Context · Plan · Execute · Verify · Improve**)를 통과합니다. `--skip-axis N`은 허용되지만 `--skip-axis 5`는 `--acknowledge-risk` 조합이 필수 — 검증 스킵은 명시적 릴리스 블로커입니다.
 
-스킬별 강제 범위는 [final-spec §3.5](./.claude/plans/2026-04-19/03-design/final-spec.md)에 정의되어 있습니다. `--skip-axis N`은 허용되지만 `--skip-axis 5`는 `--acknowledge-risk` 조합이 필수입니다 — 검증 스킵은 명시적 릴리스 블로커입니다.
+**상세** → [`docs/axes.md`](./docs/axes.md) (전체 matrix · 스킬 × 축 표 · skip 정책 근거).
 
 ---
 
@@ -91,6 +86,8 @@ git clone https://github.com/<owner>/crucible.git ~/.claude/plugins/crucible
 ```
 
 `/orchestrate`가 체크포인트 사이에서 중단되어도, 재실행 시 디스크에 기록된 마지막 CP부터 재개합니다 — 재작업 없음.
+
+**상세** → [`docs/thresholds.md`](./docs/thresholds.md) (verdict band · retry cap · overlap 가중치) · [`docs/faq.md`](./docs/faq.md) (이 기본값의 근거 · synthetic fixture 한계 · production 튜닝 로드맵).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -43,24 +43,19 @@ Runtime requirements: `bash` (≥ 4), `jq` (≥ 1.6), `uuidgen`, `flock`. No Pyt
 
 - `/brainstorm` — Feature brainstorming with a 3-lens clarify pass (vague · unknown · metamedium). Emits a requirements doc at `.claude/plans/YYYY-MM-DD-{slug}-requirements.md`.
 - `/plan` — Hybrid Markdown + YAML-frontmatter plan built from a requirements doc. Includes acceptance criteria, evaluation principles with weights, and exit conditions.
-- `/verify` — Artifact scoring with `qa-judge` (promote ≥ 0.80, retry 0.40–0.80, reject ≤ 0.40), Ralph Loop retries, and Charter Preflight.
+- `/verify` — Artifact scoring with `qa-judge`, Ralph Loop retries, and Charter Preflight.
 - `/compound` — Promotion gate for repeated patterns, user corrections, and session-wrap summaries. Only user-approved candidates reach `.claude/memory/`.
 - `/orchestrate` *(Stretch)* — End-to-end pipeline that chains the four skills above with CP-0 through CP-5 disk checkpoints for crash-safe resume.
+
+**Details** → [`docs/skills/`](./docs/skills/) (per-skill paradigm, judgment, design choices).
 
 ---
 
 ## 6-Axis Harness
 
-| # | Axis | What it enforces |
-|---|------|------------------|
-| 1 | **Structure** | Plugin layout, manifest integrity, slash-command registration |
-| 2 | **Context** | `SessionStart` hook + `using-harness` guidance + `MEMORY.md` injection |
-| 3 | **Plan** | Hybrid Markdown + YAML artifacts that humans and Evaluators both parse |
-| 4 | **Execute** | Scoped skills, hook-validated prompts, SHA256-pinned payloads |
-| 5 | **Verify** | `qa-judge` scoring · Ralph Loop · 3-stage Evaluator · grey-zone fallback |
-| 6 | **Improve** | `/compound` promotion gate → `tacit/`, `corrections/`, `preferences/` memory |
+Every artifact passes a six-axis gate: **Structure · Context · Plan · Execute · Verify · Improve**. `--skip-axis N` is permitted, but `--skip-axis 5` additionally requires `--acknowledge-risk` — skipping verification is an explicit release blocker.
 
-Enforcement scope per skill is defined in [final-spec §3.5](./.claude/plans/2026-04-19/03-design/final-spec.md). `--skip-axis N` is permitted, but `--skip-axis 5` additionally requires `--acknowledge-risk` — skipping verification is an explicit release blocker.
+**Details** → [`docs/axes.md`](./docs/axes.md) (full matrix, skill × axis grid, skip-policy rationale).
 
 ---
 
@@ -91,6 +86,8 @@ Enforcement scope per skill is defined in [final-spec §3.5](./.claude/plans/202
 ```
 
 If `/orchestrate` crashes between checkpoints, re-invocation resumes from the last CP written to disk — no rework.
+
+**Details** → [`docs/thresholds.md`](./docs/thresholds.md) (verdict bands, retry cap, overlap weights) · [`docs/faq.md`](./docs/faq.md) (why these defaults, synthetic-fixture caveat, production tuning plan).
 
 ---
 


### PR DESCRIPTION
## Summary
- T-README-09: `README.md` — 6-axis matrix relocated to `docs/axes.md`, 4 `**Details →**` pointers added (axes · skills · thresholds · faq). Install/Example sections unchanged.
- T-README-10: `README.ko.md` — 1:1 section-heading symmetry with English. Korean-only brainstorming example preserved. All pointers mirrored.

## AC
- AC-H3 PASS (matrix relocated in both files)
- AC-S1 PASS (bilingual symmetry by section heading diff)
- AC-09.3 PASS (4 pointer targets in each README)

## Next
Phase 4 (T-README-11) runs link-integrity + number-drift check.