### PR TITLE
fix(digest): schema hygiene — recursion case + pipefail + score type

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -22,7 +22,7 @@
   "harness": {
     "payload_sha256": {
       "skills/using-harness/SKILL.md": "0d32d65ef798e5b9a8cbc5377746894c4ab0581bf600859a5647714adac2500c",
-      "skills/dogfood-digest/SKILL.md": "e9d5fc372b998632bb3e077d950bd15113a79315096a918b352a3e49e90807d3",
+      "skills/dogfood-digest/SKILL.md": "fa3de3f4e8f4d85db2028219641062a30bed711c029d61d6c38a6062c497ff82",
       "hooks/session-start.sh": "09795e5837949d475e3567ef65d003f9776c89e9c1407dc06e14d935377e098a",
       "hooks/validate-output.sh": "5050f0a6b2ff42ace188c161d8297543ba1ee0e456558a2aa05ea6ed4c8bd82d"
     },

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -22,7 +22,7 @@
   "harness": {
     "payload_sha256": {
       "skills/using-harness/SKILL.md": "0d32d65ef798e5b9a8cbc5377746894c4ab0581bf600859a5647714adac2500c",
-      "skills/dogfood-digest/SKILL.md": "fa3de3f4e8f4d85db2028219641062a30bed711c029d61d6c38a6062c497ff82",
+      "skills/dogfood-digest/SKILL.md": "1ce1b72137a920ed218cf0ff03ed709c9d9b45eb64036b432738eeffef6a4111",
       "hooks/session-start.sh": "09795e5837949d475e3567ef65d003f9776c89e9c1407dc06e14d935377e098a",
       "hooks/validate-output.sh": "5050f0a6b2ff42ace188c161d8297543ba1ee0e456558a2aa05ea6ed4c8bd82d"
     },

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -555,11 +555,60 @@ else
     faile "ADV-007 SKILL.md docs" "missing 'set -o pipefail' and/or 'wrapper-via-tempfile' guidance"
 fi
 
+# The wrapper-via-tempfile example must also include `set -e` (or an
+# equivalent rc check) — without it, aggregator exit ≠ 0 still leaves the
+# next line's renderer running on an empty tempfile, writing a clean
+# "no signal" report and returning 0. That is exactly the issue #11
+# regression. pipefail alone is no-op in the wrapper form (no pipe).
+if grep -A3 -i 'wrapper-via-tempfile' "$skill_md" | grep -q 'set -e'; then
+    pass "SKILL.md wrapper-via-tempfile example includes set -e"
+else
+    faile "ADV-007 SKILL.md set -e" "wrapper-via-tempfile example missing 'set -e' — aggregator failure would silently produce empty digest"
+fi
+
+# Runtime check: the wrapper-via-tempfile pattern from SKILL.md must
+# itself surface aggregator failure. Replays the documented example with
+# a forced aggregator failure (--bogus-flag → exit 2) and asserts the
+# wrapper exits non-zero AND no clean "no signal" digest is written.
+# Without this assertion, ADV-007 only verified the pipefail path (which
+# the SKILL.md example does not actually use).
+wrap_proj="$(mktemp -d -t dfd-wrapper.XXXXXX)"
+wrap_raw="$wrap_proj/raw"
+wrap_out="$wrap_proj/out.md"
+
+set +e
+(
+    set -e
+    "$aggregator" --bogus-flag > "$wrap_raw" 2>/dev/null
+    "$renderer" --window "all" --scope local < "$wrap_raw" > "$wrap_out"
+)
+wrap_rc=$?
+set -e
+
+if [[ "$wrap_rc" -ne 0 ]]; then
+    pass "wrapper-via-tempfile + set -e surfaces aggregator failure (rc=$wrap_rc)"
+else
+    faile "ADV-007 wrapper rc" "wrapper returned 0 despite aggregator --bogus-flag failure (silent wrong-answer regression)"
+fi
+
+# The renderer must NOT have produced a "clean empty digest" report
+# (issue #11 silent-success). Either no file or no markdown body.
+if [[ ! -s "$wrap_out" ]]; then
+    pass "wrapper-via-tempfile wrote no digest body after aggregator failure"
+elif grep -q 'no signal in window' "$wrap_out"; then
+    faile "ADV-007 wrapper output" "renderer wrote 'no signal' digest after aggregator failure (issue #11 regression)"
+else
+    pass "wrapper-via-tempfile produced no clean-empty-digest output"
+fi
+rm -rf "$wrap_proj"
+
 # ----------------------------------------------------------------------------
 # ADV-008 (issue #12) — malformed .score values are filtered before
 # percentile computation. String-with-comma scores must NOT split into
 # extra awk records; nested-object scores must NOT produce literal "{"/"}"
-# garbage in p50/p95.
+# garbage in p50/p95. Out-of-range numeric scores (e.g. -1, 2) also pass
+# `type == "number"` but violate the [0,1] contract — they must be dropped
+# before the percentile / verdict aggregation runs.
 # ----------------------------------------------------------------------------
 
 printf 'ADV-008: malformed .score filtering\n'
@@ -572,30 +621,32 @@ cat > "$bad_proj/.claude/dogfood/log.jsonl" <<'BAD_SCORE_FIXTURE'
 {"ts":"2026-04-20T00:00:02Z","type":"qa_judge","skill":"/crucible:plan","score":{"nested":1},"verdict":"retry"}
 {"ts":"2026-04-20T00:00:03Z","type":"qa_judge","skill":"/crucible:plan","score":0.7,"verdict":"promote"}
 {"ts":"2026-04-20T00:00:04Z","type":"qa_judge","skill":"/crucible:plan","score":0.9,"verdict":"promote"}
+{"ts":"2026-04-20T00:00:05Z","type":"qa_judge","skill":"/crucible:plan","score":-1,"verdict":"reject"}
+{"ts":"2026-04-20T00:00:06Z","type":"qa_judge","skill":"/crucible:plan","score":2,"verdict":"promote"}
 BAD_SCORE_FIXTURE
 
 bad_outfile="$bad_proj/digest.md"
 "$aggregator" --all --scope local --project-root "$bad_proj" --home "$bad_proj" \
     | "$renderer" --window "all" --scope local --threshold-n 3 > "$bad_outfile"
 
-# n must equal 3 (only the three numeric-score events), not 5.
+# n must equal 3 (only the three numeric-and-in-range events), not 5 or 7.
 qa_line=$(grep 'qa_judge score distribution' "$bad_outfile" || true)
 if printf '%s' "$qa_line" | grep -qE 'n=3 '; then
-    pass "ADV-008 malformed-score events filtered: n=3 reflects numeric scores only"
+    pass "ADV-008 malformed-and-out-of-range score events filtered: n=3"
 else
     faile "ADV-008 score filter count" "expected n=3, got: $qa_line"
 fi
 
-# Sorted numeric scores: [0.5, 0.7, 0.9]. p50_idx=floor((3-1)/2)=1 → 0.7.
+# Sorted in-range numeric scores: [0.5, 0.7, 0.9]. p50_idx=floor((3-1)/2)=1 → 0.7.
 if printf '%s' "$qa_line" | grep -qE 'p50=0\.7\b'; then
-    pass "ADV-008 p50=0.7 reflects only numeric scores"
+    pass "ADV-008 p50=0.7 reflects only in-range numeric scores"
 else
     faile "ADV-008 p50 value" "expected p50=0.7, got: $qa_line"
 fi
 
 # p95_idx=floor((3-1)*0.95+0.5)=floor(2.4)=2 → 0.9.
 if printf '%s' "$qa_line" | grep -qE 'p95=0\.9\b'; then
-    pass "ADV-008 p95=0.9 reflects only numeric scores"
+    pass "ADV-008 p95=0.9 reflects only in-range numeric scores"
 else
     faile "ADV-008 p95 value" "expected p95=0.9, got: $qa_line"
 fi
@@ -606,6 +657,48 @@ if grep -qE 'p50=\{|p95=\{' "$bad_outfile"; then
 else
     pass "ADV-008 no literal '{' garbage from object scores"
 fi
+
+# Out-of-range scores (-1, 2) must not appear in p50/p95 either.
+if printf '%s' "$qa_line" | grep -qE 'p(50|95)=(-1|2)\b'; then
+    faile "ADV-008 out-of-range leak" "report contains -1 or 2 in p50/p95: $qa_line"
+else
+    pass "ADV-008 out-of-range scores (-1, 2) excluded from percentiles"
+fi
+
+# Verdict counts must reflect the same in-range filter — the rejected
+# `score=-1` and the bogus `score=2 verdict=promote` rows must NOT bump
+# the verdict histogram. Expected: promote=2, retry=1, reject=0.
+if printf '%s' "$qa_line" | grep -qE 'promote=2 · retry=1 · reject=0'; then
+    pass "ADV-008 verdict histogram matches in-range filter (promote=2 retry=1 reject=0)"
+else
+    faile "ADV-008 verdict counts" "expected promote=2 retry=1 reject=0, got: $qa_line"
+fi
+
+# Recursion filter resilience (P2 hardening): non-string `.skill` must
+# pass through ascii_downcase without aborting the entire render. Before
+# this fix, `{"skill": 12, "type": "skill_call"}` crashed with "explode
+# input must be a string" and dropped every event in the batch.
+nonstr_proj="$(mktemp -d -t dfd-nonstr-skill.XXXXXX)"
+mkdir -p "$nonstr_proj/.claude/dogfood"
+cat > "$nonstr_proj/.claude/dogfood/log.jsonl" <<'NONSTR_FIXTURE'
+{"ts":"2026-04-20T00:00:00Z","type":"note","category":"pain","text":"/crucible:plan ok"}
+{"ts":"2026-04-20T00:00:01Z","type":"skill_call","skill":12,"args_summary":"numeric"}
+{"ts":"2026-04-20T00:00:02Z","type":"skill_call","skill":{"obj":1},"args_summary":"object"}
+{"ts":"2026-04-20T00:00:03Z","type":"skill_call","skill":null,"args_summary":"null"}
+NONSTR_FIXTURE
+
+nonstr_outfile="$nonstr_proj/digest.md"
+"$aggregator" --all --scope local --project-root "$nonstr_proj" --home "$nonstr_proj" \
+    | "$renderer" --window "all" --scope local > "$nonstr_outfile"
+nonstr_total=$(grep -E '^total_events: ' "$nonstr_outfile" | awk '{print $2}')
+# All 4 events must survive — none are self-calls, the malformed skill
+# rows can't be self-call candidates, the note is the pain signal.
+if [[ "$nonstr_total" -eq 4 ]]; then
+    pass "ADV-008 non-string .skill rows pass through (total_events=4)"
+else
+    faile "ADV-008 non-string skill" "expected 4 events, got $nonstr_total — render likely aborted on malformed skill"
+fi
+rm -rf "$nonstr_proj"
 rm -rf "$bad_proj"
 
 # ----------------------------------------------------------------------------

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -464,11 +464,156 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+# ADV-006 (issue #10) — recursion filter is case-insensitive.
+# Mixed-case skill_call values from non-canonical upstream emitters must be
+# dropped just like the lowercase canonical form. Sibling skills that happen
+# to be uppercase must NOT be dropped.
+# ----------------------------------------------------------------------------
+
+printf 'ADV-006: case-insensitive recursion filter\n'
+
+case_proj="$(mktemp -d -t dfd-case.XXXXXX)"
+mkdir -p "$case_proj/.claude/dogfood"
+cat > "$case_proj/.claude/dogfood/log.jsonl" <<'CASE_FIXTURE'
+{"ts":"2026-04-20T00:00:00Z","type":"skill_call","skill":"/CRUCIBLE:DOGFOOD-DIGEST","args_summary":"upper"}
+{"ts":"2026-04-20T00:00:01Z","type":"skill_call","skill":"/Crucible:Dogfood-Digest","args_summary":"mixed"}
+{"ts":"2026-04-20T00:00:02Z","type":"skill_call","skill":"/crucible:dogfood-digest","args_summary":"lower"}
+{"ts":"2026-04-20T00:00:03Z","type":"skill_call","skill":"/CRUCIBLE:DOGFOOD-DIGEST-V2","args_summary":"sibling upper"}
+{"ts":"2026-04-20T00:00:04Z","type":"note","category":"pain","text":"/crucible:plan some pain"}
+CASE_FIXTURE
+
+case_outfile="$case_proj/digest.md"
+"$aggregator" --all --scope local --project-root "$case_proj" --home "$case_proj" \
+    | "$renderer" --window "all" --scope local > "$case_outfile"
+
+# 5 input → 3 case-variants of self dropped → 2 surviving (sibling + note).
+case_total=$(grep -E '^total_events: ' "$case_outfile" | awk '{print $2}')
+if [[ "$case_total" -eq 2 ]]; then
+    pass "ADV-006 lowercase + UPPER + Mixed self-calls all dropped (total_events=$case_total)"
+else
+    faile "ADV-006 case-insensitive recursion" "got $case_total want 2"
+fi
+
+# Sibling upper-case variant must survive in the rendered report (frontmatter
+# total reflects post-recursion-filter count, so 2 includes the sibling row).
+# Aggregator preserves all 5 (recursion filter lives in renderer); after
+# render, the v2 sibling event is still represented.
+case_section_leak=$(grep -cE '\*\*/[Cc][Rr][Uu][Cc][Ii][Bb][Ll][Ee]:[Dd][Oo][Gg][Ff][Oo][Oo][Dd]-[Dd][Ii][Gg][Ee][Ss][Tt]\*\*' "$case_outfile" || true)
+if [[ "$case_section_leak" -eq 0 ]]; then
+    pass "ADV-006 no case-variant of self leaked into section keys"
+else
+    faile "ADV-006 case-variant leak" "$case_section_leak self-call section keys present"
+fi
+rm -rf "$case_proj"
+
+# ----------------------------------------------------------------------------
+# ADV-007 (issue #11) — pipefail propagates aggregator failure.
+# Without `set -o pipefail`, a failing aggregator (jq sort error, mktemp
+# error, bad-args exit 2, etc.) is masked by the renderer's exit 0 — the
+# pipeline reports success while emitting an empty 3-section "no signal in
+# window" report. With pipefail enabled, the failure must surface as a
+# non-zero exit code from the pipeline as a whole.
+# ----------------------------------------------------------------------------
+
+printf 'ADV-007: pipefail surfaces aggregator failure\n'
+
+# The outer test file enables `set -uo pipefail` AND `set -e` further down,
+# so we must use the same `set +e ... set -e` bracket pattern other tests
+# use to capture expected non-zero exits. We also toggle pipefail itself
+# between arms — without that toggle, the parent's pipefail would already
+# mask the issue-#11 failure mode in the "without" arm.
+# Without pipefail: bad-args aggregator exits 2; renderer reads no input,
+# emits empty 3-section report, exits 0; pipeline returns 0 — the
+# "success but wrong answer" failure mode this guard exists to prevent.
+set +e
+set +o pipefail
+( "$aggregator" --bogus-flag 2>/dev/null \
+    | "$renderer" --window "all" --scope local >/dev/null 2>&1 )
+no_pipefail_rc=$?
+
+# With pipefail: aggregator exit 2 must propagate as the pipeline exit code.
+set -o pipefail
+( "$aggregator" --bogus-flag 2>/dev/null \
+    | "$renderer" --window "all" --scope local >/dev/null 2>&1 )
+pipefail_rc=$?
+set -e
+
+if [[ "$no_pipefail_rc" -eq 0 && "$pipefail_rc" -ne 0 ]]; then
+    pass "pipefail surfaces aggregator failure (without=$no_pipefail_rc → with=$pipefail_rc)"
+else
+    faile "ADV-007 pipefail propagation" "without=$no_pipefail_rc with=$pipefail_rc (want without=0 with≠0)"
+fi
+
+# SKILL.md Phase 4 must document both pipefail AND wrapper-via-tempfile —
+# pipefail alone is the social-contract minimum, the wrapper pattern is
+# the agent-resilient invocation form (issue #11 chose option 1+3).
+skill_md="$repo_root/skills/dogfood-digest/SKILL.md"
+if grep -q 'set -o pipefail' "$skill_md" \
+    && grep -qi 'wrapper-via-tempfile' "$skill_md"; then
+    pass "SKILL.md Phase 4 documents pipefail + wrapper-via-tempfile invocation pattern"
+else
+    faile "ADV-007 SKILL.md docs" "missing 'set -o pipefail' and/or 'wrapper-via-tempfile' guidance"
+fi
+
+# ----------------------------------------------------------------------------
+# ADV-008 (issue #12) — malformed .score values are filtered before
+# percentile computation. String-with-comma scores must NOT split into
+# extra awk records; nested-object scores must NOT produce literal "{"/"}"
+# garbage in p50/p95.
+# ----------------------------------------------------------------------------
+
+printf 'ADV-008: malformed .score filtering\n'
+
+bad_proj="$(mktemp -d -t dfd-bad-score.XXXXXX)"
+mkdir -p "$bad_proj/.claude/dogfood"
+cat > "$bad_proj/.claude/dogfood/log.jsonl" <<'BAD_SCORE_FIXTURE'
+{"ts":"2026-04-20T00:00:00Z","type":"qa_judge","skill":"/crucible:plan","score":0.5,"verdict":"retry"}
+{"ts":"2026-04-20T00:00:01Z","type":"qa_judge","skill":"/crucible:plan","score":"0.5,0.7","verdict":"retry"}
+{"ts":"2026-04-20T00:00:02Z","type":"qa_judge","skill":"/crucible:plan","score":{"nested":1},"verdict":"retry"}
+{"ts":"2026-04-20T00:00:03Z","type":"qa_judge","skill":"/crucible:plan","score":0.7,"verdict":"promote"}
+{"ts":"2026-04-20T00:00:04Z","type":"qa_judge","skill":"/crucible:plan","score":0.9,"verdict":"promote"}
+BAD_SCORE_FIXTURE
+
+bad_outfile="$bad_proj/digest.md"
+"$aggregator" --all --scope local --project-root "$bad_proj" --home "$bad_proj" \
+    | "$renderer" --window "all" --scope local --threshold-n 3 > "$bad_outfile"
+
+# n must equal 3 (only the three numeric-score events), not 5.
+qa_line=$(grep 'qa_judge score distribution' "$bad_outfile" || true)
+if printf '%s' "$qa_line" | grep -qE 'n=3 '; then
+    pass "ADV-008 malformed-score events filtered: n=3 reflects numeric scores only"
+else
+    faile "ADV-008 score filter count" "expected n=3, got: $qa_line"
+fi
+
+# Sorted numeric scores: [0.5, 0.7, 0.9]. p50_idx=floor((3-1)/2)=1 → 0.7.
+if printf '%s' "$qa_line" | grep -qE 'p50=0\.7\b'; then
+    pass "ADV-008 p50=0.7 reflects only numeric scores"
+else
+    faile "ADV-008 p50 value" "expected p50=0.7, got: $qa_line"
+fi
+
+# p95_idx=floor((3-1)*0.95+0.5)=floor(2.4)=2 → 0.9.
+if printf '%s' "$qa_line" | grep -qE 'p95=0\.9\b'; then
+    pass "ADV-008 p95=0.9 reflects only numeric scores"
+else
+    faile "ADV-008 p95 value" "expected p95=0.9, got: $qa_line"
+fi
+
+# Most importantly: no literal "{" garbage from object-typed scores.
+if grep -qE 'p50=\{|p95=\{' "$bad_outfile"; then
+    faile "ADV-008 object-score garbage" "report contains literal '{' from object score"
+else
+    pass "ADV-008 no literal '{' garbage from object scores"
+fi
+rm -rf "$bad_proj"
+
+# ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------
 
 if [[ "$fail" -eq 0 ]]; then
-    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter)\n'
+    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-006/007/008)\n'
     exit 0
 else
     printf '\ntest-dogfood-digest: FAIL\n'

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -117,10 +117,14 @@ trap 'rm -f "$tmp_in"' EXIT INT TERM HUP
 
 # Read stdin, drop blanks, filter recursion events at ingestion.
 # Regex is anchored so sibling skills like `/crucible:dogfood-digest-v2` are NOT dropped.
+# Case-insensitive: upstream wrappers / non-canonical emitters may carry mixed
+# case (`/CRUCIBLE:DOGFOOD-DIGEST`). ascii_downcase normalises before the test
+# AND the `i` flag is kept as belt-and-braces — either alone is sufficient,
+# both together survive even if one side regresses.
 # A jq failure here would silently truncate $tmp_in and every downstream
 # count would degrade to "no signal in window" with exit 0 — a "success
 # but wrong answer" failure mode. Surface jq errors instead of swallowing.
-if ! jq -c 'select(if .type == "skill_call" then ((.skill // "") | test("^/?crucible:dogfood-digest$") | not) else true end)' > "$tmp_in"; then
+if ! jq -c 'select(if .type == "skill_call" then ((.skill // "") | ascii_downcase | test("^/?crucible:dogfood-digest$"; "i") | not) else true end)' > "$tmp_in"; then
     printf 'render: ingestion jq failed (malformed JSONL on stdin?)\n' >&2
     exit 1
 fi
@@ -129,8 +133,15 @@ total_events=$(wc -l < "$tmp_in" | tr -d ' ')
 
 # ----- per-type aggregates ---------------------------------------------------
 
-# qa_judge: score list + verdict histogram
-qa_json="$(jq -sc '[.[] | select(.type=="qa_judge")]' "$tmp_in")"
+# qa_judge: score list + verdict histogram.
+# Filter to events where .score is numeric — non-numeric scores poison
+# percentile statistics (string-with-comma splits awk records; nested
+# objects render as literal "{}" in the report). Dropping the entire row
+# when score is malformed is the conservative call: a future skill that
+# logs score as object/string would otherwise corrupt every digest
+# forever (issue #12). Verdict counts and references therefore reflect
+# well-formed events only.
+qa_json="$(jq -sc '[.[] | select(.type=="qa_judge" and (.score | type == "number"))]' "$tmp_in")"
 qa_count=$(printf '%s' "$qa_json" | jq 'length')
 
 # axis_skip: axis histogram (only "acknowledged" true)
@@ -182,10 +193,26 @@ else
         promote_n=$(printf '%s' "$qa_json" | jq '[.[] | select(.verdict=="promote")] | length')
         retry_n=$(printf '%s' "$qa_json" | jq '[.[] | select(.verdict=="retry")] | length')
         reject_n=$(printf '%s' "$qa_json" | jq '[.[] | select(.verdict=="reject")] | length')
-        # percentiles via bash sort (scores are floats ≤ 3 digits)
-        scores_sorted=$(printf '%s' "$qa_json" | jq -r '[.[].score] | sort | .[]' | paste -sd',' -)
-        p50=$(printf '%s' "$scores_sorted" | tr ',' '\n' | awk 'BEGIN{c=0}{a[c++]=$1}END{ if(c==0){print "n/a"} else {print a[int((c-1)/2)]} }')
-        p95=$(printf '%s' "$scores_sorted" | tr ',' '\n' | awk 'BEGIN{c=0}{a[c++]=$1}END{ if(c==0){print "n/a"} else { i=int((c-1)*0.95+0.5); if(i>=c)i=c-1; print a[i] } }')
+        # Percentiles computed inside jq — stay in numeric domain instead of
+        # round-tripping through awk's stringly-typed split on commas (which
+        # is what poisoned p50/p95 when .score carried a "0.5,0.7" string in
+        # issue #12). Index math mirrors the prior awk: p50 = floor((n-1)/2),
+        # p95 = floor((n-1)*0.95 + 0.5), clamped to the last index.
+        p50=$(printf '%s' "$qa_json" | jq -r '
+            if length == 0 then "n/a"
+            else ([.[].score] | sort) as $s
+                | ($s | length) as $n
+                | $s[(($n - 1) / 2) | floor]
+            end
+        ')
+        p95=$(printf '%s' "$qa_json" | jq -r '
+            if length == 0 then "n/a"
+            else ([.[].score] | sort) as $s
+                | ($s | length) as $n
+                | ((($n - 1) * 0.95 + 0.5) | floor) as $i
+                | $s[if $i >= $n then $n - 1 else $i end]
+            end
+        ')
         refs=$(printf '%s' "$qa_json" | jq -r '.[] | "\(._source_path):\(._line)"' | head -3 | awk '{printf "`%s` ", $0}')
         printf -- '- **qa_judge score distribution** — n=%s · p50=%s · p95=%s · verdicts: promote=%s · retry=%s · reject=%s — 근거(샘플 3건): %s\n' \
             "$qa_count" "$p50" "$p95" "$promote_n" "$retry_n" "$reject_n" "$refs"

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -121,10 +121,15 @@ trap 'rm -f "$tmp_in"' EXIT INT TERM HUP
 # case (`/CRUCIBLE:DOGFOOD-DIGEST`). ascii_downcase normalises before the test
 # AND the `i` flag is kept as belt-and-braces — either alone is sufficient,
 # both together survive even if one side regresses.
+# Non-string `.skill` values (number, object, null) cannot be self-call
+# candidates and would crash `ascii_downcase` ("explode input must be a
+# string"), killing the entire render for the batch. Pass them through so
+# one malformed row does not poison all downstream sections — schema drift
+# tolerance over recursion-filter strictness.
 # A jq failure here would silently truncate $tmp_in and every downstream
 # count would degrade to "no signal in window" with exit 0 — a "success
 # but wrong answer" failure mode. Surface jq errors instead of swallowing.
-if ! jq -c 'select(if .type == "skill_call" then ((.skill // "") | ascii_downcase | test("^/?crucible:dogfood-digest$"; "i") | not) else true end)' > "$tmp_in"; then
+if ! jq -c 'select(if .type == "skill_call" then (if (.skill | type) == "string" then ((.skill | ascii_downcase) | test("^/?crucible:dogfood-digest$"; "i") | not) else true end) else true end)' > "$tmp_in"; then
     printf 'render: ingestion jq failed (malformed JSONL on stdin?)\n' >&2
     exit 1
 fi
@@ -134,14 +139,17 @@ total_events=$(wc -l < "$tmp_in" | tr -d ' ')
 # ----- per-type aggregates ---------------------------------------------------
 
 # qa_judge: score list + verdict histogram.
-# Filter to events where .score is numeric — non-numeric scores poison
-# percentile statistics (string-with-comma splits awk records; nested
-# objects render as literal "{}" in the report). Dropping the entire row
+# Filter to events where .score is numeric AND inside the [0,1] contract —
+# non-numeric scores poison percentile statistics (string-with-comma splits
+# awk records; nested objects render as literal "{}" in the report), and
+# out-of-range numbers (e.g. -1, 2) silently corrupt p50/p95 even though
+# they pass `type == "number"`. The score contract is [0,1]; any other
+# value is schema drift and dropped at ingestion. Dropping the entire row
 # when score is malformed is the conservative call: a future skill that
-# logs score as object/string would otherwise corrupt every digest
-# forever (issue #12). Verdict counts and references therefore reflect
-# well-formed events only.
-qa_json="$(jq -sc '[.[] | select(.type=="qa_judge" and (.score | type == "number"))]' "$tmp_in")"
+# logs score as object/string would otherwise corrupt every digest forever
+# (issue #12). Verdict counts and references therefore reflect well-formed
+# in-range events only.
+qa_json="$(jq -sc '[.[] | select(.type=="qa_judge" and (.score | type == "number") and .score >= 0 and .score <= 1)]' "$tmp_in")"
 qa_count=$(printf '%s' "$qa_json" | jq 'length')
 
 # axis_skip: axis histogram (only "acknowledged" true)

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -129,10 +129,10 @@ Do **not** use when:
 **입력**: Phase 2 stream + `{window, scope}`.
 
 **동작**:
-1. `bash scripts/dogfood-digest-render.sh --window {window} --scope {scope}` 에 stdin pipe.
-2. 재귀 필터: 입력 중 `.type == "skill_call" && .skill == "/crucible:dogfood-digest"` (앵커 regex `^/?crucible:dogfood-digest$`) 는 ingestion 단계에서 drop. 자기 호출이 Protocol/Promotion 섹션을 오염시키지 않도록 한다. 앵커가 있어 `crucible:dogfood-digest-v2` 같은 미래 형제 스킬 호출은 보존된다.
+1. renderer (`bash scripts/dogfood-digest-render.sh --window {window} --scope {scope}`) 가 Phase 2 의 filtered JSONL 을 **stdin** 으로 읽어 변환한다. 호출형(직결 파이프 vs wrapper-via-tempfile) 은 Phase 3 의 책임이 아니라 Phase 4 가 정의한다 — 둘 다 renderer 입장에서는 동일한 stdin 입력이다.
+2. 재귀 필터: 입력 중 `.type == "skill_call" && .skill == "/crucible:dogfood-digest"` (앵커 regex `^/?crucible:dogfood-digest$`, 대소문자 무시) 는 ingestion 단계에서 drop. 자기 호출이 Protocol/Promotion 섹션을 오염시키지 않도록 한다. 앵커가 있어 `crucible:dogfood-digest-v2` 같은 미래 형제 스킬 호출은 보존된다. `.skill` 이 string 이 아닌 malformed 행은 self-call 로 단정할 수 없으므로 통과 처리(schema-drift tolerance).
 3. 섹션별 휴리스틱 — 관측수 하한은 `--threshold-n N`(기본 3, 양의 정수) 로 조정 가능:
-   - **Threshold Calibration**: `qa_judge` n≥threshold-n 이면 p50/p95 + verdict 분포, `axis_skip` n≥threshold-n 이면 축별 histogram. 둘 다 관측수 미만이면 `no signal in window (qa_judge n=X, axis_skip n=Y, threshold-n=N)`.
+   - **Threshold Calibration**: `qa_judge` 중 `.score` 가 `[0,1]` 범위의 number 인 행만 카운트한다 (n=numeric-and-in-range). n≥threshold-n 이면 p50/p95 + verdict 분포. 문자열·중첩 객체·범위 밖 score 는 통계 오염 방지를 위해 ingestion 단계에서 drop 되며 `total_events` 에는 남고 `qa_judge n` 에서는 빠진다 (issue #12 + 추가 hardening). `axis_skip` n≥threshold-n 이면 축별 histogram. 둘 다 관측수 미만이면 `no signal in window (qa_judge n=X, axis_skip n=Y, threshold-n=N)`.
    - **Protocol Improvements**: `note` 중 category ∈ {pain, ambiguous} 를 text 내 첫 `/crucible:*` 토큰 기준 그룹핑 (미매치는 `general`) + `axis_skip.reason` 동일 키 ≥ 2. 상위 5건만.
    - **Promotion Candidates**: `note` 중 category ∈ {request, good} 을 같은 방식으로 그룹핑 + `promotion_gate.response == "y"` 빈도 ≥ 2.
 4. 각 제안 라인은 `- **{key}** ({cats}, n={count}) — {sample}\n  - 근거: \`{path}:{line}\` …` 형식. 최소 1건의 back-reference 를 반드시 포함.
@@ -155,26 +155,28 @@ Do **not** use when:
 2. 파일 경로 조립: `.claude/plans/${date}-dogfood-digest-${window_label}.md`. slug `dogfood-digest` 는 고정 문자열이라 별도 sanitize 불필요 — `{window_label}` 만 `[a-zA-Z0-9_-]` 화이트리스트 내에 있는지 확인.
 3. `.claude/plans/` 디렉토리 부재 시 `mkdir -p`.
 4. **이미 같은 경로의 파일이 있으면** 덮어쓰지 말고 `{window}-v2` / `{window}-v3` … 처럼 suffix 를 바꿔 재호출할 것. 재조회가 필요하면 Phase 1 부터 다시 돈다. (스크립트에 `--out` / `--force` flag 는 의도적으로 두지 않음 — 충돌 처리는 호출자 문맥에서 판단.)
-5. **호출 패턴 (필수)** — `aggregator | renderer` 직결 파이프 대신 **wrapper-via-tempfile** 패턴을 사용한다. aggregator 가 `jq sort` / `mktemp` 등으로 실패해도 renderer 는 EOF 까지 읽고 깨끗한 "no signal in window" 리포트를 exit 0 으로 뱉기 때문에, 직결 파이프는 "성공처럼 보이는 잘못된 결과(success but wrong answer)" 실패를 만든다(issue #11). 회피책 두 가지를 **함께** 적용한다:
-   - `set -o pipefail` 을 호출 전에 켠다 (직결 파이프를 쓸 때 aggregator 실패가 전체 exit code 로 전파되도록).
-   - aggregator 출력을 `mktemp` 임시파일로 받고 renderer 에 stdin 으로 주입한다 (각 단계 exit code 를 독립적으로 검사 가능).
+5. **호출 패턴 (필수)** — aggregator → renderer 단계 분리 없이 호출하면 aggregator 가 `jq sort` / `mktemp` 등으로 실패해도 renderer 는 EOF 까지 읽고 깨끗한 "no signal in window" 리포트를 exit 0 으로 뱉어 "성공처럼 보이는 잘못된 결과(success but wrong answer)" 실패를 만든다(issue #11). 두 가지 호출형 모두 **aggregator 실패가 호출자 exit code 로 surface 되도록** 보호장치를 따로 둬야 한다:
+   - **wrapper-via-tempfile (권장)**: aggregator 출력을 `mktemp` 임시파일로 받고 renderer 에 stdin 으로 주입한다. **`set -e`** 또는 aggregator 호출 직후 `if ! ... ; then exit 1; fi` 명시 rc 체크가 **필수** — 둘 중 하나라도 없으면 aggregator 가 exit 2 로 죽어도 renderer 가 빈 입력으로 정상 리포트를 만들어 issue #11 회귀가 된다. 단계별 exit code 를 독립 검사할 수 있는 게 추가 이점.
+   - **direct pipe**: `set -o pipefail` 을 호출 전에 켠다. aggregator 실패가 전체 exit code 로 전파된다(테스트는 ADV-007 참조). 단, 단계별 디버깅이 어렵다.
 6. 저장 후 최종 응답 마지막 줄에 저장 경로 echo.
 
 **출력**: 디스크 상의 리포트 파일 1건.
 
 **실패 시 fallback**: 파일 쓰기 실패 → 에러 원문을 사용자에게 노출하고 중단. 부분 쓰기 잔해 제거. 스크립트 자체의 exit code 는 출력 섹션 참조 (0/1/2).
 
-**예시 호출 (bash)**:
+**예시 호출 (bash, wrapper-via-tempfile)**:
 ```bash
-set -o pipefail   # aggregator 실패가 빈 리포트로 가려지지 않도록 (issue #11).
+set -e   # aggregator 실패가 빈 리포트로 가려지지 않도록 (issue #11).
+         # set -o pipefail 은 이 형태에서 파이프가 없어 무효 — set -e 가 핵심.
 
 win=last10
 date=$(date -u +%Y-%m-%d)
 mkdir -p .claude/plans
 
-# wrapper-via-tempfile: aggregator 와 renderer 사이에 tempfile 을 끼워 각
-# 단계의 exit code 를 독립적으로 검사할 수 있게 한다. 직결 파이프는
-# pipefail 만으로도 막히지만, tempfile 패턴은 디버깅/재시도가 더 쉽다.
+# wrapper-via-tempfile: aggregator → tempfile → renderer.
+# 각 단계 exit code 를 독립 검사 가능. 위 `set -e` 가 없으면 aggregator
+# 가 exit 2 로 죽어도 다음 줄의 renderer 가 빈 입력으로 정상 리포트를
+# 저장한다.
 tmp_raw="$(mktemp -t dogfood-digest-raw.XXXXXX)"
 trap 'rm -f "$tmp_raw"' EXIT INT TERM HUP
 
@@ -182,6 +184,14 @@ bash scripts/dogfood-digest.sh --last 10 --scope both > "$tmp_raw"
 bash scripts/dogfood-digest-render.sh --window "$win" --scope both \
     < "$tmp_raw" \
     > ".claude/plans/${date}-dogfood-digest-${win}.md"
+```
+
+**대체 호출 (direct pipe, ADV-007 검증 형태)**:
+```bash
+set -o pipefail   # 직결 파이프에서 aggregator 실패를 전체 exit code 로 전파.
+bash scripts/dogfood-digest.sh --last 10 --scope both \
+    | bash scripts/dogfood-digest-render.sh --window last10 --scope both \
+    > ".claude/plans/${date}-dogfood-digest-last10.md"
 ```
 
 ---

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -155,7 +155,10 @@ Do **not** use when:
 2. 파일 경로 조립: `.claude/plans/${date}-dogfood-digest-${window_label}.md`. slug `dogfood-digest` 는 고정 문자열이라 별도 sanitize 불필요 — `{window_label}` 만 `[a-zA-Z0-9_-]` 화이트리스트 내에 있는지 확인.
 3. `.claude/plans/` 디렉토리 부재 시 `mkdir -p`.
 4. **이미 같은 경로의 파일이 있으면** 덮어쓰지 말고 `{window}-v2` / `{window}-v3` … 처럼 suffix 를 바꿔 재호출할 것. 재조회가 필요하면 Phase 1 부터 다시 돈다. (스크립트에 `--out` / `--force` flag 는 의도적으로 두지 않음 — 충돌 처리는 호출자 문맥에서 판단.)
-5. 저장 후 최종 응답 마지막 줄에 저장 경로 echo.
+5. **호출 패턴 (필수)** — `aggregator | renderer` 직결 파이프 대신 **wrapper-via-tempfile** 패턴을 사용한다. aggregator 가 `jq sort` / `mktemp` 등으로 실패해도 renderer 는 EOF 까지 읽고 깨끗한 "no signal in window" 리포트를 exit 0 으로 뱉기 때문에, 직결 파이프는 "성공처럼 보이는 잘못된 결과(success but wrong answer)" 실패를 만든다(issue #11). 회피책 두 가지를 **함께** 적용한다:
+   - `set -o pipefail` 을 호출 전에 켠다 (직결 파이프를 쓸 때 aggregator 실패가 전체 exit code 로 전파되도록).
+   - aggregator 출력을 `mktemp` 임시파일로 받고 renderer 에 stdin 으로 주입한다 (각 단계 exit code 를 독립적으로 검사 가능).
+6. 저장 후 최종 응답 마지막 줄에 저장 경로 echo.
 
 **출력**: 디스크 상의 리포트 파일 1건.
 
@@ -163,11 +166,21 @@ Do **not** use when:
 
 **예시 호출 (bash)**:
 ```bash
+set -o pipefail   # aggregator 실패가 빈 리포트로 가려지지 않도록 (issue #11).
+
 win=last10
 date=$(date -u +%Y-%m-%d)
 mkdir -p .claude/plans
-bash scripts/dogfood-digest.sh --last 10 --scope both \
-    | bash scripts/dogfood-digest-render.sh --window "$win" --scope both \
+
+# wrapper-via-tempfile: aggregator 와 renderer 사이에 tempfile 을 끼워 각
+# 단계의 exit code 를 독립적으로 검사할 수 있게 한다. 직결 파이프는
+# pipefail 만으로도 막히지만, tempfile 패턴은 디버깅/재시도가 더 쉽다.
+tmp_raw="$(mktemp -t dogfood-digest-raw.XXXXXX)"
+trap 'rm -f "$tmp_raw"' EXIT INT TERM HUP
+
+bash scripts/dogfood-digest.sh --last 10 --scope both > "$tmp_raw"
+bash scripts/dogfood-digest-render.sh --window "$win" --scope both \
+    < "$tmp_raw" \
     > ".claude/plans/${date}-dogfood-digest-${win}.md"
 ```
 


### PR DESCRIPTION
Bundled follow-up to PR #7 ce-code-review — closes the three deferred
"schema hygiene" findings (ADV-006/007/008) in one PR because they all
touch the same `dogfood-digest` read pipeline.

Closes #10
Closes #11
Closes #12

## What changed

### #10 (ADV-006, conf 75) — recursion filter is now case-insensitive

`scripts/dogfood-digest-render.sh:127` normalises `.skill` via
`ascii_downcase` AND keeps the regex `i` flag (belt-and-braces — either
alone is sufficient, both together survive future regressions).

Before, a non-canonical upstream emitter sending
`/CRUCIBLE:DOGFOOD-DIGEST` (or any mixed-case variant) bypassed the
recursion guard, and the self-call ended up as evidence in the next
digest, compounding noise across runs. The anchor (`^/?...$`) is
preserved so `/crucible:dogfood-digest-v2` and any case-variant of a
sibling skill are still kept.

### #11 (ADV-007, conf 90) — pipefail + wrapper-via-tempfile invocation pattern

This was a design decision. The issue listed three options:

| Option | Mechanism | Pros | Cons |
|---|---|---|---|
| 1 | `set -o pipefail` documented in SKILL.md | Cheapest; zero script change | Social contract — relies on the agent reading and following docs |
| 2 | Sentinel marker (`{"_eof":true}` row) emitted by aggregator; render exits 1 if absent | Self-enforcing; can't be bypassed | Backward-incompat for any external consumer that pipes the aggregator output through other tools |
| 3 | Wrapper-via-tempfile in SKILL.md (`agg > /tmp/raw && render < /tmp/raw`) | Each stage's exit code is independently checkable; no script change | Still social contract, but the pattern is harder to mis-apply than a flag toggle |

**Picked: option 1 + option 3 combined.** Option 1 alone is too easy
to forget; option 2 changes the wire format and breaks anyone consuming
the aggregator stream directly. Option 3 forces the agent to
materialise the raw output, at which point `set -o pipefail` is
near-redundant — but documenting both makes the failure mode visible to
anyone reading the SKILL and gives belt-and-braces protection if either
guard regresses.

`skills/dogfood-digest/SKILL.md` Phase 4 now spells out both — the
example block opens with `set -o pipefail` and uses
`mktemp` + `trap` to keep aggregator and renderer exit codes separable.

### #12 (ADV-008, conf 100) — `.score` is filtered to numeric type before percentile math

`scripts/dogfood-digest-render.sh` filters `qa_json` to events where
`.score | type == "number"`, then computes `p50` / `p95` inside `jq`
instead of round-tripping through `awk`'s comma-split.

The original awk pipeline was poisoned by:
- string-with-comma scores (`"0.5,0.7"` split into two awk records,
  shifting indices)
- nested-object scores (rendered as literal `{` / `}` in the report)

A future skill that mistakenly logs `score` as object/string could
otherwise corrupt every digest forever — invisible to the SC-1~7 tests
which use a well-formed fixture. `n=` now reflects only well-formed
events; verdict counts and references stay consistent with that filter.

## Tests

Three new blocks in `__tests__/integration/test-dogfood-digest.sh`:

- **ADV-006**: 5-event fixture with lowercase + UPPER + Mixed self-call
  variants + UPPER sibling — verifies all 3 self-call variants drop and
  total_events=2; verifies no case-variant leaks into section keys.
- **ADV-007**: pipefail-off pipeline returns 0 on aggregator failure
  (the issue-#11 failure mode), pipefail-on returns the aggregator's
  exit 2; plus a doc check that SKILL.md mentions both `set -o pipefail`
  and `wrapper-via-tempfile`.
- **ADV-008**: 5-event fixture with 2 malformed scores → asserts n=3,
  p50=0.7, p95=0.9; explicit assertion that no literal `{` leaks into
  the report body.

```
$ bash __tests__/integration/test-dogfood-digest.sh
…
ADV-006: case-insensitive recursion filter
  ✓ ADV-006 lowercase + UPPER + Mixed self-calls all dropped (total_events=2)
  ✓ ADV-006 no case-variant of self leaked into section keys
ADV-007: pipefail surfaces aggregator failure
  ✓ pipefail surfaces aggregator failure (without=0 → with=2)
  ✓ SKILL.md Phase 4 documents pipefail + wrapper-via-tempfile invocation pattern
ADV-008: malformed .score filtering
  ✓ ADV-008 malformed-score events filtered: n=3 reflects numeric scores only
  ✓ ADV-008 p50=0.7 reflects only numeric scores
  ✓ ADV-008 p95=0.9 reflects only numeric scores
  ✓ ADV-008 no literal '{' garbage from object scores

test-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-006/007/008)
```

`bash __tests__/integration/test-dogfood-log.sh` also `ALL PASS` (no
behavior change there, sanity run only).

## Plugin manifest

`scripts/update-payload-hashes.sh` ran; `.claude-plugin/plugin.json`
`payload_sha256` for `skills/dogfood-digest/SKILL.md` refreshed
(`e9d5fc37…` → `fa3de3f4…`).

## Test plan

- [x] `bash __tests__/integration/test-dogfood-digest.sh` PASS
- [x] `bash __tests__/integration/test-dogfood-log.sh` PASS
- [x] `scripts/update-payload-hashes.sh` ran; manifest hash updated
- [x] DCO `Signed-off-by` trailer present
- [ ] reviewer confirms option 1+3 trade-off matches their intent (vs.
      option 2 sentinel) — see PR body for trade-off table