### PR TITLE
docs(digest): split SKILL.md input: into agg/renderer subgroups + agg --help cross-ref

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -22,7 +22,7 @@
   "harness": {
     "payload_sha256": {
       "skills/using-harness/SKILL.md": "0d32d65ef798e5b9a8cbc5377746894c4ab0581bf600859a5647714adac2500c",
-      "skills/dogfood-digest/SKILL.md": "1ce1b72137a920ed218cf0ff03ed709c9d9b45eb64036b432738eeffef6a4111",
+      "skills/dogfood-digest/SKILL.md": "29efbfc99cdf8bc88efc6da75a54494e7287fbc3d7e1bb719778b0eaf6bb8cc5",
       "hooks/session-start.sh": "09795e5837949d475e3567ef65d003f9776c89e9c1407dc06e14d935377e098a",
       "hooks/validate-output.sh": "5050f0a6b2ff42ace188c161d8297543ba1ee0e456558a2aa05ea6ed4c8bd82d"
     },

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -702,11 +702,44 @@ rm -rf "$nonstr_proj"
 rm -rf "$bad_proj"
 
 # ----------------------------------------------------------------------------
+# Issue #15 — aggregator/renderer flag-grouping cross-reference
+# (cli-readiness cli-1 + agent-native F1)
+# ----------------------------------------------------------------------------
+
+printf 'ISSUE-15: aggregator rejects --threshold-n with renderer cross-ref hint\n'
+
+# (a) aggregator must exit 2 on --threshold-n AND emit a stderr hint that
+#     mentions dogfood-digest-render.sh so a naive agent can self-recover.
+i15_stderr="$(mktemp -t dfd-i15-err.XXXXXX)"
+i15_rc=0
+"$aggregator" --threshold-n 5 --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>"$i15_stderr" || i15_rc=$?
+if [[ "$i15_rc" -eq 2 ]]; then
+    pass "aggregator exits 2 when --threshold-n is passed"
+else
+    faile "issue-15 exit code" "expected 2, got $i15_rc"
+fi
+if grep -q 'dogfood-digest-render.sh' "$i15_stderr"; then
+    pass "aggregator stderr hints at dogfood-digest-render.sh on --threshold-n"
+else
+    faile "issue-15 stderr hint" "expected 'dogfood-digest-render.sh' in stderr; got: $(tr '\n' '|' < "$i15_stderr")"
+fi
+rm -f "$i15_stderr"
+
+# (b) aggregator --help must cross-reference renderer for render-time flags so
+#     agents discover --threshold-n placement without reading source.
+i15_help="$("$aggregator" --help 2>&1)"
+if grep -qE 'render-time flags|dogfood-digest-render\.sh --help' <<<"$i15_help"; then
+    pass "aggregator --help cross-references renderer for render-time flags"
+else
+    faile "issue-15 help cross-ref" "expected 'render-time flags' or 'dogfood-digest-render.sh --help' in --help output"
+fi
+
+# ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------
 
 if [[ "$fail" -eq 0 ]]; then
-    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-006/007/008)\n'
+    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-006/007/008 + issue-15)\n'
     exit 0
 else
     printf '\ntest-dogfood-digest: FAIL\n'

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -718,10 +718,23 @@ if [[ "$i15_rc" -eq 2 ]]; then
 else
     faile "issue-15 exit code" "expected 2, got $i15_rc"
 fi
-if grep -q 'dogfood-digest-render.sh' "$i15_stderr"; then
-    pass "aggregator stderr hints at dogfood-digest-render.sh on --threshold-n"
+# Anchor on the targeted-hint discriminator (`hint —` AND `render-time flag`)
+# so deleting the case "$1" in --window|--threshold-n) block in
+# scripts/dogfood-digest.sh actually breaks this assertion. The bare string
+# "dogfood-digest-render.sh" was satisfied by the print_help cross-reference
+# alone (see codex review on pr #21) — the assertion would have stayed green
+# even with the targeted hint removed.
+if grep -q 'hint —' "$i15_stderr" && grep -q 'is a render-time flag' "$i15_stderr"; then
+    pass "aggregator stderr emits targeted misroute hint on --threshold-n"
 else
-    faile "issue-15 stderr hint" "expected 'dogfood-digest-render.sh' in stderr; got: $(tr '\n' '|' < "$i15_stderr")"
+    faile "issue-15 stderr hint" "expected 'hint —' and 'is a render-time flag' in stderr; got: $(tr '\n' '|' < "$i15_stderr")"
+fi
+# Hint must reference the renderer script by name so a naive agent can
+# self-recover without re-reading the help text.
+if grep -q 'dogfood-digest-render.sh' "$i15_stderr"; then
+    pass "aggregator stderr hint names dogfood-digest-render.sh"
+else
+    faile "issue-15 hint script name" "expected 'dogfood-digest-render.sh' in stderr; got: $(tr '\n' '|' < "$i15_stderr")"
 fi
 rm -f "$i15_stderr"
 

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -123,12 +123,21 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             printf 'dogfood-digest: unknown argument: %s\n' "$1" >&2
+            # Recognized misroute: render-time flag passed to the aggregator.
+            # Skip the ~40-line print_help dump and emit just the targeted
+            # hint plus a one-line pointer to --help. The wall of help text
+            # would scroll the actionable hint off screen on terminals with
+            # short scrollback (codex pr#21 review). For unrecognized flags
+            # the full help is still useful as a discovery aid.
             case "$1" in
                 --window|--threshold-n)
                     printf 'dogfood-digest: hint — %s is a render-time flag; pass it to scripts/dogfood-digest-render.sh instead.\n' "$1" >&2
+                    printf 'dogfood-digest: for full usage: bash scripts/dogfood-digest.sh --help\n' >&2
+                    ;;
+                *)
+                    print_help >&2
                     ;;
             esac
-            print_help >&2
             exit 2
             ;;
     esac

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -65,6 +65,9 @@ Exit codes:
   0  success
   1  runtime failure
   2  argument error
+
+For render-time flags (--window, --threshold-n), see:
+  bash scripts/dogfood-digest-render.sh --help
 USAGE
 }
 
@@ -120,6 +123,11 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             printf 'dogfood-digest: unknown argument: %s\n' "$1" >&2
+            case "$1" in
+                --window|--threshold-n)
+                    printf 'dogfood-digest: hint — %s is a render-time flag; pass it to scripts/dogfood-digest-render.sh instead.\n' "$1" >&2
+                    ;;
+            esac
             print_help >&2
             exit 2
             ;;

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -6,25 +6,31 @@ description: |
   트리거: "dogfood digest", "도그푸드 다이제스트", "도그푸드 리포트", "dogfood report", "/crucible:dogfood-digest", "로그 집계 제안", "dogfood summary", "피드백 요약".
 when_to_use: "dogfood JSONL이 여러 건 누적된 뒤, 임계값·스킬 프로토콜·승격 후보 개선 아이디어를 사람이 읽고 판단할 수 있는 제안 리포트로 뽑아내고 싶을 때. 수동 호출 전용 — Stop hook / cron 자동 실행 없음."
 input: |
-  Window / scope 플래그 (user-facing):
+  플래그는 두 스크립트로 나뉘며, 잘못된 쪽에 패스하면 unknown-argument
+  로 exit 2 한다. `--scope` 만 양쪽이 공유한다.
+
+  Aggregator (`scripts/dogfood-digest.sh`) — window · scope · 경로 resolve:
     --last N           최근 N 이벤트 (기본 10). 양의 정수.
     --since DATE|Nd    절대 날짜(YYYY-MM-DD / ISO8601) 또는 상대 기간(예: 7d).
     --all              전체 window. --last/--since 조합은 error(exit 2),
                        --all 이 함께 오면 overrides.
     --scope local|global|both   기본 both.
-
-  Render knob:
-    --threshold-n N    Threshold 섹션에서 qa_judge / axis_skip 관측수 하한
-                       (기본 3). 양의 정수만 허용. renderer 스크립트에 직접
-                       전달 가능.
-
-  Path overrides (CI/test only — 프로덕션 호출 시 미지정):
-    --project-root DIR        PWD 대신 사용할 로컬 로그 루트.
-    --home DIR                $HOME 대신 사용할 글로벌 mirror 루트.
+    --project-root DIR (CI/test only) PWD 대신 사용할 로컬 로그 루트.
+    --home DIR         (CI/test only) $HOME 대신 사용할 글로벌 mirror 루트.
     env CRUCIBLE_DOGFOOD_ROOT  위 --project-root 보다 우선. 적용 시 stderr 에 info.
     env CRUCIBLE_DOGFOOD_HOME  위 --home 보다 우선. 적용 시 stderr 에 info.
 
-  입력 소스 (최종 resolve):
+  Renderer (`scripts/dogfood-digest-render.sh`) — Markdown 변환 단계 knob.
+  **`--threshold-n` 은 renderer 전용** — aggregator 에 전달하면 unknown
+  argument 로 exit 2 한다.
+    --window LABEL     window 라벨(파일명 + frontmatter, 필수). 호출자가
+                       aggregator 의 window 플래그에 맞춰 합성한다.
+    --scope local|global|both   기본 both. aggregator 의 --scope 와 동일하게
+                       검증되어 frontmatter 의 `scope:` 에 그대로 쓰인다.
+    --threshold-n N    Threshold 섹션에서 qa_judge / axis_skip 관측수 하한
+                       (기본 3). 양의 정수만 허용.
+
+  입력 소스 (aggregator 가 resolve, renderer 는 stdin 만 읽음):
     로컬  `${CRUCIBLE_DOGFOOD_ROOT:-${PROJECT_ROOT}}/.claude/dogfood/log.jsonl`
     글로벌 `${CRUCIBLE_DOGFOOD_HOME:-$HOME}/.claude/dogfood/crucible/{slug}-{hash}/log.jsonl`
 output: |
@@ -181,7 +187,8 @@ tmp_raw="$(mktemp -t dogfood-digest-raw.XXXXXX)"
 trap 'rm -f "$tmp_raw"' EXIT INT TERM HUP
 
 bash scripts/dogfood-digest.sh --last 10 --scope both > "$tmp_raw"
-bash scripts/dogfood-digest-render.sh --window "$win" --scope both \
+# --threshold-n 은 renderer 에만 — aggregator 에 패스하면 exit 2.
+bash scripts/dogfood-digest-render.sh --window "$win" --scope both --threshold-n 5 \
     < "$tmp_raw" \
     > ".claude/plans/${date}-dogfood-digest-${win}.md"
 ```
@@ -189,8 +196,9 @@ bash scripts/dogfood-digest-render.sh --window "$win" --scope both \
 **대체 호출 (direct pipe, ADV-007 검증 형태)**:
 ```bash
 set -o pipefail   # 직결 파이프에서 aggregator 실패를 전체 exit code 로 전파.
+# --threshold-n 은 파이프 오른쪽(renderer) 에만 둔다.
 bash scripts/dogfood-digest.sh --last 10 --scope both \
-    | bash scripts/dogfood-digest-render.sh --window last10 --scope both \
+    | bash scripts/dogfood-digest-render.sh --window last10 --scope both --threshold-n 5 \
     > ".claude/plans/${date}-dogfood-digest-last10.md"
 ```
 


### PR DESCRIPTION
Closes #15.

## Problem

`skills/dogfood-digest/SKILL.md` listed `--last`, `--since`, `--all`, `--scope`, `--project-root`, `--home`, `--threshold-n` together in one `input:` block with no indication that **`--threshold-n` is renderer-only**. An agent reading SKILL.md naively calls `bash scripts/dogfood-digest.sh --threshold-n 5` and gets `unknown argument` (exit 2) with no hint where to redirect the flag.

Source: ce-code-review on PR #7 — `cli-readiness` finding `cli-1` (conf 90), corroborated by `agent-native` finding F1.

## Changes

Pure docs/UX — no behavior change to the JSONL pipeline.

- **`skills/dogfood-digest/SKILL.md`**
  - `input:` regrouped into **Aggregator (`scripts/dogfood-digest.sh`)** and **Renderer (`scripts/dogfood-digest-render.sh`)** subgroups, with an explicit note that `--threshold-n` is renderer-only and `--scope` is the only shared flag.
  - Phase 4 wrapper-via-tempfile + direct-pipe examples now show `--threshold-n 5` on the renderer side, giving agents a worked reference for correct placement.
- **`scripts/dogfood-digest.sh`**
  - `--help` gains a "see also" line: `bash scripts/dogfood-digest-render.sh --help` for render-time flags.
  - Unknown-argument error path adds a targeted hint when the offending flag is `--window` or `--threshold-n`, naming the renderer script so a misrouted call self-recovers without a code dive.
- **`__tests__/integration/test-dogfood-digest.sh`**
  - New `ISSUE-15` block: aggregator exits 2 on `--threshold-n`, stderr mentions `dogfood-digest-render.sh`, `--help` cross-references the renderer. Locks the docs/UX contract in CI.
- **`.claude-plugin/plugin.json`**
  - SHA256 payload hash refresh for changed payloads (via `scripts/update-payload-hashes.sh`).

## Test plan

- [x] `bash __tests__/integration/test-dogfood-digest.sh` → ALL PASS (SC-1~7 + recursion filter + ADV-006/007/008 + issue-15)
- [x] `bash __tests__/integration/test-dogfood-log.sh`   → ALL PASS (SC-1~5)
- [x] Three new ISSUE-15 sub-checks pass:
  - aggregator exits 2 when `--threshold-n` is passed
  - aggregator stderr hints at `dogfood-digest-render.sh` on `--threshold-n`
  - aggregator `--help` cross-references renderer for render-time flags
- [ ] (reviewer) confirm SKILL.md `input:` reads cleanly and the worked Phase 4 example matches actual renderer flags