### PR TITLE
fix(digest): prune stale dogfood-digest tempfiles on startup

### DIFF
--- a/__tests__/integration/test-ac-issue13-stale-tempfile-cleanup.sh
+++ b/__tests__/integration/test-ac-issue13-stale-tempfile-cleanup.sh
@@ -1,0 +1,124 @@
+#!/usr/bin/env bash
+# __tests__/integration/test-ac-issue13-stale-tempfile-cleanup.sh
+#
+# Regression coverage for issue #13 (ADV-009, conf 100):
+#   SIGKILL/OOM-kill bypasses the EXIT/INT/TERM/HUP trap in
+#   scripts/dogfood-digest.sh and scripts/dogfood-digest-render.sh, leaking
+#   `dogfood-digest-raw.*` (aggregator, plus `.sorted` siblings) and
+#   `dogfood-digest-in.*` (renderer) tempfiles into $TMPDIR.
+#
+# The fix adds a startup `find ... -mmin +60 -delete` pass before each
+# script's `mktemp` call. This test:
+#   1. Plants a stale orphan (mtime well beyond 60 min) in $TMPDIR.
+#   2. Plants a fresh file (current mtime) under the same prefix.
+#   3. Runs the script under test in a sandboxed empty project.
+#   4. Asserts the stale file was pruned and the fresh file was preserved.
+#
+# Exit 0 = both scripts pass. Exit 1 = at least one assertion failed.
+
+set -uo pipefail
+
+repo_root="$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)"
+aggregator="$repo_root/scripts/dogfood-digest.sh"
+renderer="$repo_root/scripts/dogfood-digest-render.sh"
+
+for f in "$aggregator" "$renderer"; do
+    if [[ ! -r "$f" ]]; then
+        printf 'FAIL: missing prerequisite: %s\n' "$f" >&2
+        exit 1
+    fi
+done
+
+fail=0
+pass() { printf '  ✓ %s\n' "$1"; }
+faile() { fail=1; printf '  ✗ %s — %s\n' "$1" "${2:-}"; }
+
+# Use a fresh isolated TMPDIR so we never delete the real user's tempfiles.
+tmproot="$(mktemp -d -t dfd-issue13.XXXXXX)"
+tmpproj="$(mktemp -d -t dfd-issue13-proj.XXXXXX)"
+tmphome="$(mktemp -d -t dfd-issue13-home.XXXXXX)"
+trap 'rm -rf "$tmproot" "$tmpproj" "$tmphome"' EXIT
+
+# Project sandbox is intentionally empty (no log.jsonl) so the aggregator
+# exits with zero sources after the cleanup pass runs. That is the path we
+# want exercised — we are not testing aggregation here, only the prune.
+mkdir -p "$tmpproj/.claude/dogfood"
+
+# Pre-compute a ~120-min-ago mtime stamp portable across BSD (macOS) and GNU
+# date. -t accepts [[CC]YY]MMDDhhmm[.SS] on both BSD touch and GNU touch.
+stamp="$(date -u -r "$(( $(date -u +%s) - 7200 ))" +%Y%m%d%H%M.%S 2>/dev/null \
+        || date -u -d "@$(( $(date -u +%s) - 7200 ))" +%Y%m%d%H%M.%S)"
+
+# ---------------------------------------------------------------------------
+# Aggregator: dogfood-digest-raw.* prune
+# ---------------------------------------------------------------------------
+
+printf '\n[1/2] dogfood-digest.sh — stale dogfood-digest-raw.* prune\n'
+
+stale_raw="$tmproot/dogfood-digest-raw.STALEXX"
+stale_sorted="$tmproot/dogfood-digest-raw.STALEYY.sorted"
+fresh_raw="$tmproot/dogfood-digest-raw.FRESHXX"
+
+: > "$stale_raw"
+: > "$stale_sorted"
+: > "$fresh_raw"
+
+touch -t "$stamp" "$stale_raw" "$stale_sorted"
+
+TMPDIR="$tmproot" "$aggregator" --all --scope local \
+    --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+
+if [[ ! -e "$stale_raw" ]]; then
+    pass "stale dogfood-digest-raw.* pruned on startup"
+else
+    faile "stale dogfood-digest-raw.* survived startup prune" "still present at $stale_raw"
+fi
+if [[ ! -e "$stale_sorted" ]]; then
+    pass "stale dogfood-digest-raw.*.sorted pruned on startup"
+else
+    faile "stale dogfood-digest-raw.*.sorted survived startup prune" "still present at $stale_sorted"
+fi
+if [[ -e "$fresh_raw" ]]; then
+    pass "fresh dogfood-digest-raw.* preserved (mtime within 60min window)"
+else
+    faile "fresh dogfood-digest-raw.* incorrectly pruned" "missing $fresh_raw"
+fi
+
+# ---------------------------------------------------------------------------
+# Renderer: dogfood-digest-in.* prune
+# ---------------------------------------------------------------------------
+
+printf '\n[2/2] dogfood-digest-render.sh — stale dogfood-digest-in.* prune\n'
+
+stale_in="$tmproot/dogfood-digest-in.STALEXX"
+fresh_in="$tmproot/dogfood-digest-in.FRESHXX"
+
+: > "$stale_in"
+: > "$fresh_in"
+
+touch -t "$stamp" "$stale_in"
+
+# Renderer reads JSONL on stdin; pipe an empty stream so it produces an
+# empty-section report and exits 0. The startup cleanup runs before the
+# mktemp call regardless of input shape.
+printf '' | TMPDIR="$tmproot" "$renderer" --window all >/dev/null 2>&1
+
+if [[ ! -e "$stale_in" ]]; then
+    pass "stale dogfood-digest-in.* pruned on startup"
+else
+    faile "stale dogfood-digest-in.* survived startup prune" "still present at $stale_in"
+fi
+if [[ -e "$fresh_in" ]]; then
+    pass "fresh dogfood-digest-in.* preserved (mtime within 60min window)"
+else
+    faile "fresh dogfood-digest-in.* incorrectly pruned" "missing $fresh_in"
+fi
+
+printf '\n'
+if [[ "$fail" -eq 0 ]]; then
+    printf 'PASS — issue #13 stale-tempfile cleanup\n'
+    exit 0
+else
+    printf 'FAIL — issue #13 stale-tempfile cleanup\n' >&2
+    exit 1
+fi

--- a/__tests__/integration/test-ac-issue13-stale-tempfile-cleanup.sh
+++ b/__tests__/integration/test-ac-issue13-stale-tempfile-cleanup.sh
@@ -44,10 +44,23 @@ trap 'rm -rf "$tmproot" "$tmpproj" "$tmphome"' EXIT
 # want exercised — we are not testing aggregation here, only the prune.
 mkdir -p "$tmpproj/.claude/dogfood"
 
-# Pre-compute a ~120-min-ago mtime stamp portable across BSD (macOS) and GNU
-# date. -t accepts [[CC]YY]MMDDhhmm[.SS] on both BSD touch and GNU touch.
-stamp="$(date -u -r "$(( $(date -u +%s) - 7200 ))" +%Y%m%d%H%M.%S 2>/dev/null \
-        || date -u -d "@$(( $(date -u +%s) - 7200 ))" +%Y%m%d%H%M.%S)"
+# Pre-compute mtime stamps as ISO8601 UTC strings so `touch -d` interprets
+# them as absolute UTC instants. `touch -t` would parse the prior
+# YYYYMMDDhhmm.SS form in *local* time, which silently shifts the mtime by
+# the local TZ offset (e.g. KST=+9h pushed a 30-min stamp ~9.5h into the
+# past — surviving 60-min prunes for a different reason than intended).
+# Both BSD (macOS) and GNU touch accept the `-d ISO8601[Z]` form.
+stamp="$(date -u -r "$(( $(date -u +%s) - 7200 ))" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -d "@$(( $(date -u +%s) - 7200 ))" +%Y-%m-%dT%H:%M:%SZ)"
+
+# Pre-compute a ~30-min-ago mtime stamp for the lower-bound assertion: files
+# *just under* the 60-minute prune boundary must survive. This catches a
+# regression that flips `find ... -mmin +60` to `-mmin -60` (the opposite
+# condition), which would still pass the upper-bound (~120 min) and fresh
+# (current mtime) assertions but silently delete files inside the 60-minute
+# window — exactly the runs the prune is designed to spare.
+stamp_30="$(date -u -r "$(( $(date -u +%s) - 1800 ))" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null \
+        || date -u -d "@$(( $(date -u +%s) - 1800 ))" +%Y-%m-%dT%H:%M:%SZ)"
 
 # ---------------------------------------------------------------------------
 # Aggregator: dogfood-digest-raw.* prune
@@ -58,12 +71,15 @@ printf '\n[1/2] dogfood-digest.sh — stale dogfood-digest-raw.* prune\n'
 stale_raw="$tmproot/dogfood-digest-raw.STALEXX"
 stale_sorted="$tmproot/dogfood-digest-raw.STALEYY.sorted"
 fresh_raw="$tmproot/dogfood-digest-raw.FRESHXX"
+recent_raw="$tmproot/dogfood-digest-raw.RECENT30"
 
 : > "$stale_raw"
 : > "$stale_sorted"
 : > "$fresh_raw"
+: > "$recent_raw"
 
-touch -t "$stamp" "$stale_raw" "$stale_sorted"
+touch -d "$stamp" "$stale_raw" "$stale_sorted"
+touch -d "$stamp_30" "$recent_raw"
 
 TMPDIR="$tmproot" "$aggregator" --all --scope local \
     --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
@@ -83,6 +99,11 @@ if [[ -e "$fresh_raw" ]]; then
 else
     faile "fresh dogfood-digest-raw.* incorrectly pruned" "missing $fresh_raw"
 fi
+if [[ -e "$recent_raw" ]]; then
+    pass "30-min-old dogfood-digest-raw.* preserved (lower-bound: just under 60min)"
+else
+    faile "30-min-old dogfood-digest-raw.* incorrectly pruned" "missing $recent_raw — find condition may have flipped from -mmin +60 to -mmin -60"
+fi
 
 # ---------------------------------------------------------------------------
 # Renderer: dogfood-digest-in.* prune
@@ -92,11 +113,14 @@ printf '\n[2/2] dogfood-digest-render.sh — stale dogfood-digest-in.* prune\n'
 
 stale_in="$tmproot/dogfood-digest-in.STALEXX"
 fresh_in="$tmproot/dogfood-digest-in.FRESHXX"
+recent_in="$tmproot/dogfood-digest-in.RECENT30"
 
 : > "$stale_in"
 : > "$fresh_in"
+: > "$recent_in"
 
-touch -t "$stamp" "$stale_in"
+touch -d "$stamp" "$stale_in"
+touch -d "$stamp_30" "$recent_in"
 
 # Renderer reads JSONL on stdin; pipe an empty stream so it produces an
 # empty-section report and exits 0. The startup cleanup runs before the
@@ -112,6 +136,11 @@ if [[ -e "$fresh_in" ]]; then
     pass "fresh dogfood-digest-in.* preserved (mtime within 60min window)"
 else
     faile "fresh dogfood-digest-in.* incorrectly pruned" "missing $fresh_in"
+fi
+if [[ -e "$recent_in" ]]; then
+    pass "30-min-old dogfood-digest-in.* preserved (lower-bound: just under 60min)"
+else
+    faile "30-min-old dogfood-digest-in.* incorrectly pruned" "missing $recent_in — find condition may have flipped from -mmin +60 to -mmin -60"
 fi
 
 printf '\n'

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -107,6 +107,15 @@ if ! [[ "$threshold_n" =~ ^[0-9]+$ ]] || [[ "$threshold_n" -le 0 ]]; then
     exit 2
 fi
 
+# Best-effort cleanup of stale orphans from prior SIGKILL/OOM-kill runs.
+# The EXIT/INT/TERM/HUP trap below handles graceful exits, but SIGKILL is
+# untrappable by design — every kill -9 leaks a dogfood-digest-in.XXXXXX of
+# size O(JSONL bytes) into $TMPDIR. Long-lived dev/CI environments accumulate
+# these until mktemp itself errors out. 60-minute window is far longer than
+# any real render run; stderr suppression + `|| true` keep the prune
+# best-effort so any pruning failure never blocks a legitimate run.
+find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'dogfood-digest-in.*' -mmin +60 -delete 2>/dev/null || true
+
 tmp_in="$(mktemp -t dogfood-digest-in.XXXXXX)" || {
     printf 'render: mktemp failed\n' >&2
     exit 2

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -87,6 +87,17 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Best-effort cleanup of stale orphans from prior SIGKILL/OOM-kill runs.
+# Placed right after argument parsing — *before* --window/--scope/--threshold-n
+# validation — so the prune still fires on arg-error retries that follow a
+# SIGKILL'd run (the very paths that leak tempfiles in the first place). The
+# EXIT/INT/TERM/HUP trap below handles graceful exits, but SIGKILL is
+# untrappable by design — every kill -9 leaks a dogfood-digest-in.XXXXXX of
+# size O(JSONL bytes) into $TMPDIR. 60-minute window is far longer than any
+# real render run; stderr suppression + `|| true` keep the prune best-effort
+# so any pruning failure never blocks a legitimate run.
+find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'dogfood-digest-in.*' -mmin +60 -delete 2>/dev/null || true
+
 if [[ -z "$window_label" ]]; then
     printf 'render: --window is required\n' >&2
     exit 2
@@ -106,15 +117,6 @@ if ! [[ "$threshold_n" =~ ^[0-9]+$ ]] || [[ "$threshold_n" -le 0 ]]; then
     printf 'render: --threshold-n expects a positive integer (got: %s)\n' "$threshold_n" >&2
     exit 2
 fi
-
-# Best-effort cleanup of stale orphans from prior SIGKILL/OOM-kill runs.
-# The EXIT/INT/TERM/HUP trap below handles graceful exits, but SIGKILL is
-# untrappable by design — every kill -9 leaks a dogfood-digest-in.XXXXXX of
-# size O(JSONL bytes) into $TMPDIR. Long-lived dev/CI environments accumulate
-# these until mktemp itself errors out. 60-minute window is far longer than
-# any real render run; stderr suppression + `|| true` keep the prune
-# best-effort so any pruning failure never blocks a legitimate run.
-find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'dogfood-digest-in.*' -mmin +60 -delete 2>/dev/null || true
 
 tmp_in="$(mktemp -t dogfood-digest-in.XXXXXX)" || {
     printf 'render: mktemp failed\n' >&2

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -228,6 +228,18 @@ if [[ "$scope" == "global" || "$scope" == "both" ]]; then
     fi
 fi
 
+# Best-effort cleanup of stale orphans from prior SIGKILL/OOM-kill runs.
+# The EXIT/INT/TERM/HUP trap below handles graceful exits, but SIGKILL is
+# untrappable by design — every kill -9 leaks a dogfood-digest-raw.XXXXXX
+# (and its .sorted sibling) of size O(JSONL bytes) into $TMPDIR. Long-lived
+# dev/CI environments accumulate these until mktemp itself errors out.
+# 60-minute window is far longer than any real digest run; -mmin is honoured
+# by both BSD (macOS) and GNU find. Stderr suppression + `|| true` keep the
+# prune best-effort: any pruning failure (permission, missing TMPDIR) must
+# never block a legitimate run. Placed before the zero-sources fast-path so
+# the prune still happens on no-input invocations.
+find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'dogfood-digest-raw.*' -mmin +60 -delete 2>/dev/null || true
+
 # Zero sources = zero output (SC-6 compliant). Exit 0 silently.
 if [[ "${#sources[@]}" -eq 0 ]]; then
     exit 0

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -126,6 +126,19 @@ while [[ $# -gt 0 ]]; do
     esac
 done
 
+# Best-effort cleanup of stale orphans from prior SIGKILL/OOM-kill runs.
+# Placed right after argument parsing — *before* mutex/scope/cutoff/source
+# resolution — so the prune still fires on malformed-config invocations and
+# on arg-error retries that follow a SIGKILL'd run (the very paths that leak
+# tempfiles in the first place). The EXIT/INT/TERM/HUP trap below handles
+# graceful exits, but SIGKILL is untrappable by design — every kill -9 leaks
+# a dogfood-digest-raw.XXXXXX (and its .sorted sibling) of size O(JSONL
+# bytes) into $TMPDIR. 60-minute window is far longer than any real digest
+# run; -mmin is honoured by both BSD (macOS) and GNU find. Stderr suppression
+# + `|| true` keep the prune best-effort: any pruning failure (permission,
+# missing TMPDIR) must never block a legitimate run.
+find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'dogfood-digest-raw.*' -mmin +60 -delete 2>/dev/null || true
+
 # Mutex: --last and --since cannot be combined. --all takes precedence and
 # collapses the conflict (documented as "--all overrides both").
 if [[ "$saw_all" -eq 0 && "$saw_last" -eq 1 && "$saw_since" -eq 1 ]]; then
@@ -227,18 +240,6 @@ if [[ "$scope" == "global" || "$scope" == "both" ]]; then
         done < <(find "$global_glob" -type f -name 'log.jsonl' -print0 2>/dev/null)
     fi
 fi
-
-# Best-effort cleanup of stale orphans from prior SIGKILL/OOM-kill runs.
-# The EXIT/INT/TERM/HUP trap below handles graceful exits, but SIGKILL is
-# untrappable by design — every kill -9 leaks a dogfood-digest-raw.XXXXXX
-# (and its .sorted sibling) of size O(JSONL bytes) into $TMPDIR. Long-lived
-# dev/CI environments accumulate these until mktemp itself errors out.
-# 60-minute window is far longer than any real digest run; -mmin is honoured
-# by both BSD (macOS) and GNU find. Stderr suppression + `|| true` keep the
-# prune best-effort: any pruning failure (permission, missing TMPDIR) must
-# never block a legitimate run. Placed before the zero-sources fast-path so
-# the prune still happens on no-input invocations.
-find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'dogfood-digest-raw.*' -mmin +60 -delete 2>/dev/null || true
 
 # Zero sources = zero output (SC-6 compliant). Exit 0 silently.
 if [[ "${#sources[@]}" -eq 0 ]]; then


### PR DESCRIPTION
Closes #13.

## Summary

`scripts/dogfood-digest.sh` and `scripts/dogfood-digest-render.sh` rely on
`trap … EXIT INT TERM HUP` (added in PR #7) to remove their `mktemp`
buffers. SIGKILL and OOM-kill bypass that trap by design, leaking
`dogfood-digest-raw.*` (+ `.sorted` siblings, aggregator) and
`dogfood-digest-in.*` (renderer) into `$TMPDIR`. ADV-009 (conf 100)
flagged the slow accumulation in long-lived dev/CI environments.

This PR adds a best-effort startup prune to both scripts:

```bash
find "${TMPDIR:-/tmp}" -maxdepth 1 -name '<prefix>.*' -mmin +60 -delete 2>/dev/null || true
```

- 60-minute window is far longer than any real digest run.
- `2>/dev/null || true` keeps the prune **best-effort** — a permission
  error or missing `$TMPDIR` must never block a legitimate run.
- `-maxdepth 1` keeps the search shallow (mktemp creates files directly
  in `$TMPDIR`, never in subdirs).
- The aggregator's prune is placed **before** the zero-sources
  fast-path so it still runs on no-input invocations — the most likely
  path right after a SIGKILL'd run.

Existing PR #7 traps remain unchanged (per scope: kept as-is).

## Files

- `scripts/dogfood-digest.sh` — startup prune for `dogfood-digest-raw.*`
- `scripts/dogfood-digest-render.sh` — startup prune for `dogfood-digest-in.*`
- `__tests__/integration/test-ac-issue13-stale-tempfile-cleanup.sh` — new
  regression test that plants stale + fresh files in an isolated
  `TMPDIR` and asserts only the >60-min orphans are deleted.

## Test plan

- [x] New test passes:
  ```
  bash __tests__/integration/test-ac-issue13-stale-tempfile-cleanup.sh
  → PASS — issue #13 stale-tempfile cleanup
  ```
  All 5 assertions green (3 aggregator + 2 renderer).

- [x] Existing digest suite still passes:
  ```
  bash __tests__/integration/test-dogfood-digest.sh
  → test-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-006/007/008)
  ```

- [x] Manual SIGKILL repro from the issue still cleans up on next run:
  one stale `dogfood-digest-raw.STALE…` planted, next aggregator run
  removes it (verified by `test-ac-issue13` step 1).

## Guardrails

- bash 4 + jq + uuidgen + flock only — no Python/Node introduced.
- DCO: commit signed off.
- Conventional Commits (`fix:`).
- Scope discipline: existing trap lines untouched (PR #7 territory).