### PR TITLE
fix(digest): normalize or reject ISO8601 TZ-offset in --since

### DIFF
--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -168,6 +168,84 @@ else
     faile "--since 99999d" "got $since_rc want 2"
 fi
 
+# ADV-003 (issue #8): --since with TZ-offset ISO8601 must be rejected. Without
+# the regex tightening, `2099-01-01T00:00:00+09:00` flowed through to jq's
+# lexicographic compare, where '+' (0x2B) < 'Z' (0x5A) shifted the window by
+# hours and silently matched events the user did not intend.
+printf 'ADV-003: --since TZ-offset rejected, Z-suffix preserved\n'
+
+# Future TZ-offset cutoff: must be REJECTED with exit 2 (not silently accepted).
+set +e
+tz_stderr=$("$aggregator" --since '2099-01-01T00:00:00+09:00' --scope local \
+    --project-root "$tmpproj" --home "$tmphome" 2>&1 >/dev/null)
+tz_rc=$?
+set -e
+if [[ "$tz_rc" -eq 2 ]]; then
+    pass "--since TZ-offset (+09:00) exits 2"
+else
+    faile "ADV-003 TZ-offset rc" "got $tz_rc want 2"
+fi
+if printf '%s' "$tz_stderr" | grep -q 'Z (UTC) suffix'; then
+    pass "--since TZ-offset error names Z (UTC) suffix as the fix"
+else
+    faile "ADV-003 TZ-offset error message" "stderr did not mention Z (UTC) suffix"
+fi
+
+# Negative TZ-offset is the same failure class — must also exit 2.
+set +e
+"$aggregator" --since '2099-01-01T00:00:00-08:00' --scope local \
+    --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+neg_rc=$?
+set -e
+if [[ "$neg_rc" -eq 2 ]]; then
+    pass "--since negative TZ-offset (-08:00) exits 2"
+else
+    faile "ADV-003 negative TZ-offset" "got $neg_rc want 2"
+fi
+
+# Naive datetime (no TZ designator at all) is ambiguous and must also be
+# rejected — same lexicographic-compare hazard, just less obvious.
+set +e
+"$aggregator" --since '2099-01-01T00:00:00' --scope local \
+    --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+naive_rc=$?
+set -e
+if [[ "$naive_rc" -eq 2 ]]; then
+    pass "--since naive datetime (no TZ) exits 2"
+else
+    faile "ADV-003 naive datetime" "got $naive_rc want 2"
+fi
+
+# Z-suffix ISO8601 must continue to work — regression guard for the existing
+# accepted form. Use a future cutoff so the result is independent of fixture ts.
+z_count=$("$aggregator" --since '2099-01-01T00:00:00Z' --scope local \
+    --project-root "$tmpproj" --home "$tmphome" | wc -l | tr -d ' ')
+if [[ "$z_count" -eq 0 ]]; then
+    pass "--since Z-suffix '2099-01-01T00:00:00Z' still accepted (returns 0 events)"
+else
+    faile "ADV-003 Z-suffix regression" "got $z_count want 0"
+fi
+
+# Date-only and Nd inputs must be unaffected by the regex tightening.
+date_only_count=$("$aggregator" --since 2099-01-01 --scope local \
+    --project-root "$tmpproj" --home "$tmphome" | wc -l | tr -d ' ')
+if [[ "$date_only_count" -eq 0 ]]; then
+    pass "--since date-only '2099-01-01' unaffected (returns 0 events)"
+else
+    faile "ADV-003 date-only regression" "got $date_only_count want 0"
+fi
+
+set +e
+"$aggregator" --since 7d --scope local \
+    --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+dur_rc=$?
+set -e
+if [[ "$dur_rc" -eq 0 ]]; then
+    pass "--since duration '7d' unaffected (exit 0)"
+else
+    faile "ADV-003 duration regression" "got $dur_rc want 0"
+fi
+
 # cli-readiness #2: render.sh must validate --scope, mirroring the aggregator.
 # Without it, --scope foo silently lands as "scope: foo" in the YAML
 # frontmatter — divergent semantics across the two scripts.
@@ -752,7 +830,7 @@ fi
 # ----------------------------------------------------------------------------
 
 if [[ "$fail" -eq 0 ]]; then
-    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-006/007/008 + issue-15)\n'
+    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-15)\n'
     exit 0
 else
     printf '\ntest-dogfood-digest: FAIL\n'

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -226,6 +226,45 @@ else
     faile "ADV-003 Z-suffix regression" "got $z_count want 0"
 fi
 
+# Z-suffix with fractional seconds must also be accepted — `date -u +...%NZ`
+# and `jq -n now | strftime` both produce this shape, and rejecting it forced
+# users into the wrong error path on PR #23 review (the rejection message told
+# them to add Z, which they had already done).
+z_frac_count=$("$aggregator" --since '2099-01-01T00:00:00.123Z' --scope local \
+    --project-root "$tmpproj" --home "$tmphome" | wc -l | tr -d ' ')
+if [[ "$z_frac_count" -eq 0 ]]; then
+    pass "--since Z-suffix with fractional seconds '2099-01-01T00:00:00.123Z' accepted (returns 0 events)"
+else
+    faile "ADV-003 Z-suffix fractional" "got $z_frac_count want 0"
+fi
+
+# Fractional seconds must NOT exit 2 — pin the contract so a future regex
+# tightening cannot silently regress to the rejection path.
+set +e
+"$aggregator" --since '2099-01-01T00:00:00.123Z' --scope local \
+    --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+z_frac_rc=$?
+set -e
+if [[ "$z_frac_rc" -eq 0 ]]; then
+    pass "--since Z-suffix fractional exits 0 (regex accepts, no error path)"
+else
+    faile "ADV-003 Z-suffix fractional rc" "got $z_frac_rc want 0"
+fi
+
+# Error message for malformed datetimes must describe the expected shape
+# rather than impute "non-UTC datetime". The previous wording was misleading
+# for naive datetimes (no TZ marker at all) and contradicted user input on
+# fractional-Z (which is now accepted, but the contract should still hold).
+set +e
+shape_stderr=$("$aggregator" --since '2099-01-01T00:00:00+09:00' --scope local \
+    --project-root "$tmpproj" --home "$tmphome" 2>&1 >/dev/null)
+set -e
+if printf '%s' "$shape_stderr" | grep -q 'must be YYYY-MM-DDTHH:MM:SSZ'; then
+    pass "--since malformed-TZ error describes expected shape"
+else
+    faile "ADV-003 shape error" "stderr did not describe expected shape"
+fi
+
 # Date-only and Nd inputs must be unaffected by the regex tightening.
 date_only_count=$("$aggregator" --since 2099-01-01 --scope local \
     --project-root "$tmpproj" --home "$tmphome" | wc -l | tr -d ' ')

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -12,8 +12,9 @@
 #   --last <N>           take the most recent N events (default 10 when no
 #                        window flag is given)
 #   --since <DATE|Nd>    take events with ts >= cutoff. Accepts absolute
-#                        YYYY-MM-DD / ISO8601, or "Nd" duration (e.g. 7d = 7 days
-#                        ago relative to now).
+#                        YYYY-MM-DD or YYYY-MM-DDTHH:MM:SSZ (Z/UTC required —
+#                        see issue #8), or "Nd" duration (e.g. 7d = 7 days ago
+#                        relative to now).
 #   --all                no filter (entire window)
 #   --scope SCOPE        local | global | both (default both)
 #   --project-root DIR   (CI/test only) override PWD for local log resolution
@@ -217,10 +218,20 @@ if [[ "$window_mode" == "since" ]]; then
         fi
     elif [[ "$window_since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
         cutoff_iso="${window_since}T00:00:00Z"
-    elif [[ "$window_since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]; then
+    elif [[ "$window_since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
         cutoff_iso="$window_since"
+    elif [[ "$window_since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]; then
+        # Reject TZ-offset (`+HH:MM`, `-0800`, etc.) and naive datetimes.
+        # cutoff_iso feeds jq's lexicographic ts compare, where '+' (0x2B)
+        # sorts below 'Z' (0x5A) — silently shifting the window by hours.
+        # See issue #8 (ADV-003): `--since 2026-04-15T10:00:00+09:00` matched
+        # events ~9h earlier than intended. Force UTC form so the compare is
+        # unambiguous; date-only and Nd inputs are unaffected.
+        printf 'dogfood-digest: --since ISO8601 must use Z (UTC) suffix; got non-UTC datetime: %s\n' "$window_since" >&2
+        printf '  → rewrite as YYYY-MM-DDTHH:MM:SSZ (UTC) or YYYY-MM-DD\n' >&2
+        exit 2
     else
-        printf 'dogfood-digest: --since must be YYYY-MM-DD, full ISO8601, or Nd (got: %s)\n' "$window_since" >&2
+        printf 'dogfood-digest: --since must be YYYY-MM-DD, YYYY-MM-DDTHH:MM:SSZ, or Nd (got: %s)\n' "$window_since" >&2
         exit 2
     fi
 fi

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -218,17 +218,29 @@ if [[ "$window_mode" == "since" ]]; then
         fi
     elif [[ "$window_since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}$ ]]; then
         cutoff_iso="${window_since}T00:00:00Z"
-    elif [[ "$window_since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$ ]]; then
+    elif [[ "$window_since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}(\.[0-9]+)?Z$ ]]; then
+        # Accept optional fractional seconds (e.g. `T10:00:00.123Z`) — GNU
+        # `date -u +%Y-%m-%dT%H:%M:%S.%NZ` and `jq -n now | strftime` both
+        # produce this shape, and rejecting it forced users into the wrong
+        # error path on PR #23 review (codex). Lex compare against
+        # second-precision `.ts` strings stays safe: '.' (0x2E) sorts below
+        # 'Z' (0x5A), so a fractional cutoff only *widens* the inclusion
+        # window vs. the equivalent second-precision cutoff (more events
+        # included at the boundary second, never fewer) — no silent shift.
         cutoff_iso="$window_since"
     elif [[ "$window_since" =~ ^[0-9]{4}-[0-9]{2}-[0-9]{2}T ]]; then
-        # Reject TZ-offset (`+HH:MM`, `-0800`, etc.) and naive datetimes.
-        # cutoff_iso feeds jq's lexicographic ts compare, where '+' (0x2B)
-        # sorts below 'Z' (0x5A) — silently shifting the window by hours.
-        # See issue #8 (ADV-003): `--since 2026-04-15T10:00:00+09:00` matched
-        # events ~9h earlier than intended. Force UTC form so the compare is
-        # unambiguous; date-only and Nd inputs are unaffected.
-        printf 'dogfood-digest: --since ISO8601 must use Z (UTC) suffix; got non-UTC datetime: %s\n' "$window_since" >&2
-        printf '  → rewrite as YYYY-MM-DDTHH:MM:SSZ (UTC) or YYYY-MM-DD\n' >&2
+        # Catches TZ-offset (`+HH:MM`, `-0800`, etc.) and naive datetimes
+        # (no TZ marker at all). cutoff_iso feeds jq's lexicographic ts
+        # compare, where '+' (0x2B) sorts below 'Z' (0x5A) — silently
+        # shifting the window by hours. See issue #8 (ADV-003):
+        # `--since 2026-04-15T10:00:00+09:00` matched events ~9h earlier
+        # than intended. Force UTC form so the compare is unambiguous;
+        # date-only and Nd inputs are unaffected. Message describes the
+        # expected shape (instead of imputing "non-UTC datetime") so the
+        # user can map the error to their input regardless of which
+        # malformed shape they passed.
+        printf 'dogfood-digest: --since ISO8601 must be YYYY-MM-DDTHH:MM:SSZ (UTC); got: %s\n' "$window_since" >&2
+        printf '  → rewrite with Z (UTC) suffix, or pass YYYY-MM-DD\n' >&2
         exit 2
     else
         printf 'dogfood-digest: --since must be YYYY-MM-DD, YYYY-MM-DDTHH:MM:SSZ, or Nd (got: %s)\n' "$window_since" >&2


### PR DESCRIPTION
## Summary

Closes #8 (ADV-003 from PR #7 ce-code-review, conf 90).

`--since` accepted ISO8601 inputs with a TZ-offset (`+HH:MM`, `-HHMM`) and stored the raw string in `cutoff_iso`. jq's downstream `ts >= cutoff` is a **lexicographic** string compare, where `'+'` (0x2B) sorts below `'Z'` (0x5A). Result: `--since '2026-04-15T10:00:00+09:00'` matched events whose `ts` was `2026-04-15T01:00:00Z`+ — about 9 hours earlier than the user intended. Naive datetimes (no TZ designator at all) had the same hazard.

## Fix

Tighten `scripts/dogfood-digest.sh:188` regex to accept only `YYYY-MM-DDTHH:MM:SSZ` (Z/UTC suffix). Any other ISO8601-looking input with a `T` is rejected with an actionable error pointing at the Z (UTC) form or plain date.

```
dogfood-digest: --since ISO8601 must use Z (UTC) suffix; got non-UTC datetime: 2026-04-15T10:00:00+09:00
  → rewrite as YYYY-MM-DDTHH:MM:SSZ (UTC) or YYYY-MM-DD
```

### Why rejection over `date -u -d` normalisation

Both options are listed in the issue. Chose rejection because:
- `date -u -d` works on GNU but BSD `date -j -f "%Y-%m-%dT%H:%M:%S%z"` doesn't tolerate the `:` in `+09:00` and the format string has to match exactly — pre-stripping the colon for BSD adds maintenance surface.
- Internally `cutoff_iso` is always Z-form (date-only and `Nd` paths already normalise to `T00:00:00Z`). Narrowing the input contract instead of widening the parser keeps the lexicographic-compare invariant unambiguous everywhere downstream.
- Clearer UX: the error tells the user exactly what to type instead of silently shifting their window.

## Scope guard

- `--last`, `--scope`, the `Nd` duration branch, and the date-only branch are untouched. ADV-003 tests assert each is unaffected.
- The sort-step concern noted in the issue body (line 246, mixed-TZ JSONL `ts` strings) is **not** in this PR — internally produced JSONL is always Z-form, and that codepath sits outside the issue title's `--since` scope.

## Test plan

- [x] `bash __tests__/integration/test-dogfood-digest.sh` — ADV-003 block passes (8 new assertions). All prior SC-1~7, ADV-001/002/004/006/007/008 still pass.
- [x] `bash __tests__/integration/test-dogfood-log.sh` — unchanged, still passes.
- [x] DCO sign-off present on the commit.

### ADV-003 coverage

| Input | Before | After |
|-------|--------|-------|
| `2099-01-01T00:00:00+09:00` | silently accepted, wrong window | exit 2, error names Z (UTC) suffix |
| `2099-01-01T00:00:00-08:00` | silently accepted, wrong window | exit 2 |
| `2099-01-01T00:00:00` (naive) | silently accepted, wrong window | exit 2 |
| `2099-01-01T00:00:00Z` | accepted | accepted (regression guard) |
| `2099-01-01` (date-only) | accepted | accepted (regression guard) |
| `7d` (duration) | accepted | accepted (regression guard) |