### PR TITLE
fix(digest): dedup single-flags + cap --last (issues #9, #14)

### DIFF
--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -944,6 +944,72 @@ else
     faile "single-flag regression" "got $ok_count want 5"
 fi
 
+# Single-occurrence regression guard for the OTHER dedup'd flags. Without
+# these, a regression flipping `reject_duplicate`'s saw-check (`-eq 0`
+# instead of `-eq 1`) would only be caught on the --last path (PR #24
+# ce-review testing gap).
+set +e
+single_scope_rc=$("$aggregator" --scope local --last 3 --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1; echo $?)
+set -e
+if [[ "$single_scope_rc" -eq 0 ]]; then
+    pass "single occurrence --scope still accepted (no false-positive dedup)"
+else
+    faile "single --scope regression" "got rc=$single_scope_rc want 0"
+fi
+set +e
+single_all_rc=$("$aggregator" --all --scope local --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1; echo $?)
+set -e
+if [[ "$single_all_rc" -eq 0 ]]; then
+    pass "single occurrence --all still accepted"
+else
+    faile "single --all regression" "got rc=$single_all_rc want 0"
+fi
+set +e
+single_since_rc=$("$aggregator" --since 7d --scope local --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1; echo $?)
+set -e
+if [[ "$single_since_rc" -eq 0 ]]; then
+    pass "single occurrence --since still accepted"
+else
+    faile "single --since regression" "got rc=$single_since_rc want 0"
+fi
+# --project-root and --home are exercised by every test above (passed once);
+# their single-use path is implicitly regression-guarded by the rest of the
+# suite running green.
+
+# Dedup must fire BEFORE other validations. If `--scope local --scope
+# global` ALSO has a value-validation issue (e.g. paired with `--since
+# garbage`), the dedup error must win — pinning ordering so a future
+# refactor cannot silently move the dedup check after value validation
+# (PR #24 ce-review testing gap).
+set +e
+order_err=$("$aggregator" --scope local --scope global --since invalid_value \
+    --project-root "$tmpproj" --home "$tmphome" 2>&1 >/dev/null)
+order_rc=$?
+set -e
+if [[ "$order_rc" -eq 2 ]] && printf '%s' "$order_err" | grep -F -q -- '--scope passed more than once'; then
+    pass "dedup fires before value validation (--scope dup wins over --since invalid)"
+else
+    faile "dedup ordering" "rc=$order_rc stderr=$(tr '\n' '|' <<<"$order_err")"
+fi
+
+# --last as the final positional arg: `shift 2 || …` guard must fire with
+# its own error message (not fall through to a confusing `unknown
+# argument: <next-flag>` after consuming the wrong value). PR #24
+# ce-review testing gap.
+set +e
+trailing_err=$("$aggregator" --scope local --last 2>&1 >/dev/null)
+trailing_rc=$?
+set -e
+# `--last` with no value → the case body assigns "${2:-}" which is empty,
+# `shift 2` fails on missing positional, the guard fires. Some shells
+# instead let the empty-string flow through to validation. Either way, the
+# script must exit 2 cleanly without a confusing unrelated error.
+if [[ "$trailing_rc" -eq 2 ]]; then
+    pass "--last as final arg exits 2 (shift guard or value validation)"
+else
+    faile "trailing --last" "got $trailing_rc want 2"
+fi
+
 # ----------------------------------------------------------------------------
 # Issue #14 — extreme --last and tail-failure surfacing
 # Two layers of defense: (1) parse-time cap rejects values bash arithmetic
@@ -984,15 +1050,19 @@ else
     faile "ISSUE-14 cap+1" "got $over_rc want 2"
 fi
 
-# (c) At-cap (1000000) must succeed (boundary regression guard).
+# (c) At-cap (1000000) must succeed (boundary regression guard) AND return
+#     the same number of events as --all (since fixture << 1M). Without the
+#     line-count assertion, a regression silently capping output to a
+#     smaller value (e.g. wrapping `tail` to a low constant) would still
+#     pass (PR #24 ce-review testing gap).
 set +e
-"$aggregator" --last 1000000 --scope local --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+at_cap_count=$("$aggregator" --last 1000000 --scope local --project-root "$tmpproj" --home "$tmphome" 2>/dev/null | wc -l | tr -d ' ')
 at_cap_rc=$?
 set -e
-if [[ "$at_cap_rc" -eq 0 ]]; then
-    pass "--last 1000000 succeeds (cap is inclusive of 1000000)"
+if [[ "$at_cap_rc" -eq 0 && "$at_cap_count" -eq "$fixture_lines" ]]; then
+    pass "--last 1000000 succeeds and returns all $fixture_lines fixture rows"
 else
-    faile "ISSUE-14 at-cap" "got $at_cap_rc want 0"
+    faile "ISSUE-14 at-cap" "rc=$at_cap_rc count=$at_cap_count want rc=0 count=$fixture_lines"
 fi
 
 # (d) Pipeline empty-output sanity: --last with extreme value must NOT produce

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -1024,12 +1024,150 @@ fi
 # pre-pipefail capture path; the assertion lives in huge_pipe_rc above.
 : "$huge_pipe_out"
 
+# (e) Pinning the post-arithmetic upper bound: a 7-digit value that PASSES the
+#     length cap but EXCEEDS 1000000 must be rejected by the second guard.
+#     Without this, the two-layer defense degrades silently to single-layer
+#     when the length-bound check never fires (PR #24 review test gap).
+set +e
+"$aggregator" --last 9999999 --scope local --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+worst7_rc=$?
+set -e
+if [[ "$worst7_rc" -eq 2 ]]; then
+    pass "--last 9999999 (7 digits, > cap) rejected by post-arithmetic guard (exit 2)"
+else
+    faile "ISSUE-14 7-digit overcap" "got $worst7_rc want 2 — second guard regressed"
+fi
+
+# (f) --last 0 (boundary at the bottom edge) must reject. The split
+#     regex/length/post-arithmetic path now routes 0 through the post-
+#     arithmetic `-le 0` branch, which the prior tests did not exercise.
+set +e
+"$aggregator" --last 0 --scope local --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+zero_rc=$?
+set -e
+if [[ "$zero_rc" -eq 2 ]]; then
+    pass "--last 0 rejected (post-arithmetic -le 0 guard)"
+else
+    faile "ISSUE-14 --last 0" "got $zero_rc want 2"
+fi
+
+# (g) Unified error message: both the length-cap branch and the post-
+#     arithmetic branch must emit the SAME template (PR #24 P3 #5). Two
+#     templates force stderr scrapers to handle both. Anchor on the
+#     `<= 1000000` constraint (ASCII for non-UTF-8 capture safety) so a
+#     future divergence regresses to FAIL.
+for input in 99999999999999999999 1000001; do
+    set +e
+    err=$("$aggregator" --last "$input" --scope local --project-root "$tmpproj" --home "$tmphome" 2>&1 >/dev/null)
+    set -e
+    if printf '%s' "$err" | grep -F -q -- '<= 1000000' && \
+       ! printf '%s' "$err" | grep -F -q -- 'too large'; then
+        pass "--last $input emits unified ASCII '<= 1000000' template (no 'too large' divergence)"
+    else
+        faile "ISSUE-14 unified message for --last $input" "stderr=$(tr '\n' '|' <<<"$err")"
+    fi
+done
+
+# ----------------------------------------------------------------------------
+# Issue #14 (mirror) — renderer --threshold-n is the same arithmetic-overflow
+# surface as --last. PR #24 ce-review P1 #1 surfaced that the same
+# `99999999999999999999` overflow path that produces a silent empty digest on
+# the aggregator side ALSO produces a silent empty digest on the renderer
+# side: every `[[ qa_count -ge threshold_n ]]` becomes false, all sections
+# collapse to "no signal in window", exit 0. Mirror the cap + tests here so
+# the issue stays closed across both halves of the pipeline.
+# ----------------------------------------------------------------------------
+
+printf 'ISSUE-14-MIRROR: --threshold-n cap on renderer\n'
+
+# Overflow value rejected at parse time.
+set +e
+huge_tn_err=$(echo '' | "$renderer" --window t --scope local --threshold-n 99999999999999999999 2>&1 >/dev/null)
+huge_tn_rc=$?
+set -e
+if [[ "$huge_tn_rc" -eq 2 ]]; then
+    pass "--threshold-n 99999999999999999999 exits 2 (parse-time cap)"
+else
+    faile "ISSUE-14-MIRROR overflow rc" "got $huge_tn_rc want 2 — bash arithmetic likely silently failed"
+fi
+if printf '%s' "$huge_tn_err" | grep -F -q -- '<= 1000000'; then
+    pass "--threshold-n overflow error names the cap (1000000)"
+else
+    faile "ISSUE-14-MIRROR overflow message" "stderr did not name the 1000000 cap: $(tr '\n' '|' <<<"$huge_tn_err")"
+fi
+
+# Just-over-cap (1000001) rejected.
+set +e
+echo '' | "$renderer" --window t --scope local --threshold-n 1000001 >/dev/null 2>&1
+tn_over_rc=$?
+set -e
+if [[ "$tn_over_rc" -eq 2 ]]; then
+    pass "--threshold-n 1000001 exits 2 (cap+1)"
+else
+    faile "ISSUE-14-MIRROR cap+1" "got $tn_over_rc want 2"
+fi
+
+# At-cap (1000000) accepted (boundary regression guard).
+set +e
+echo '' | "$renderer" --window t --scope local --threshold-n 1000000 >/dev/null 2>&1
+tn_at_cap_rc=$?
+set -e
+if [[ "$tn_at_cap_rc" -eq 0 ]]; then
+    pass "--threshold-n 1000000 succeeds (cap inclusive)"
+else
+    faile "ISSUE-14-MIRROR at-cap" "got $tn_at_cap_rc want 0"
+fi
+
+# 7-digit value > cap rejected by post-arithmetic guard.
+set +e
+echo '' | "$renderer" --window t --scope local --threshold-n 9999999 >/dev/null 2>&1
+tn_worst7_rc=$?
+set -e
+if [[ "$tn_worst7_rc" -eq 2 ]]; then
+    pass "--threshold-n 9999999 rejected by post-arithmetic guard"
+else
+    faile "ISSUE-14-MIRROR 7-digit overcap" "got $tn_worst7_rc want 2"
+fi
+
+# ----------------------------------------------------------------------------
+# Help-text constraint exposure (PR #24 P2 #2 + #3) — agents that consult
+# `--help` must discover the cap and at-most-once contract there too. Without
+# these assertions, a future cleanup that strips the Constraints block from
+# print_help passes silently.
+# ----------------------------------------------------------------------------
+
+printf 'HELP-CONSTRAINTS: --help mentions cap + at-most-once\n'
+
+agg_help=$("$aggregator" --help 2>&1)
+if printf '%s' "$agg_help" | grep -F -q -- '1000000'; then
+    pass "aggregator --help mentions 1000000 cap"
+else
+    faile "agg --help cap" "no '1000000' in help output"
+fi
+if printf '%s' "$agg_help" | grep -F -q -- 'at most once'; then
+    pass "aggregator --help mentions at-most-once contract"
+else
+    faile "agg --help dedup" "no 'at most once' in help output"
+fi
+
+ren_help=$("$renderer" --help 2>&1)
+if printf '%s' "$ren_help" | grep -F -q -- '1000000'; then
+    pass "renderer --help mentions 1000000 cap"
+else
+    faile "render --help cap" "no '1000000' in help output"
+fi
+if printf '%s' "$ren_help" | grep -F -q -- 'at most once'; then
+    pass "renderer --help mentions at-most-once contract"
+else
+    faile "render --help dedup" "no 'at most once' in help output"
+fi
+
 # ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------
 
 if [[ "$fail" -eq 0 ]]; then
-    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-9/14/15)\n'
+    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-9/14/15 + 14-mirror + help-constraints)\n'
     exit 0
 else
     printf '\ntest-dogfood-digest: FAIL\n'

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -865,11 +865,171 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+# Issue #9 — duplicate single-flag rejection (aggregator + renderer)
+# Without dedup, `--scope local --scope global` silently kept the LAST value,
+# producing a digest whose frontmatter labelled it `scope: global` while the
+# wrapper believed scope was local — wrong-context attribution downstream.
+# ----------------------------------------------------------------------------
+
+printf 'ISSUE-9: duplicate single-flag rejection\n'
+
+# (a) aggregator: each named flag must be at-most-once.
+for flag_pair in '--scope local --scope global' \
+                 '--last 5 --last 10' \
+                 '--all --all' \
+                 '--project-root /tmp --project-root /var' \
+                 '--home /tmp --home /var'; do
+    set +e
+    # shellcheck disable=SC2086
+    err=$("$aggregator" $flag_pair --scope local 2>&1 >/dev/null)
+    rc=$?
+    set -e
+    # The duplicate-flag branch must fire BEFORE any other validation can
+    # mask it (e.g. --scope local + --scope global must reject as duplicate,
+    # not as "valid scope" silently overwritten).
+    case "$flag_pair" in
+        --scope*) flag_name="--scope" ;;
+        --last*)  flag_name="--last" ;;
+        --all*)   flag_name="--all" ;;
+        --project-root*) flag_name="--project-root" ;;
+        --home*)  flag_name="--home" ;;
+    esac
+    # `grep -F --` so flag-named patterns like `--scope passed more than once`
+    # are not interpreted as grep options (BSD grep on macOS rejects them).
+    if [[ "$rc" -eq 2 ]] && printf '%s' "$err" | grep -F -q -- "${flag_name} passed more than once"; then
+        pass "aggregator rejects duplicate $flag_name (exit 2 + named in stderr)"
+    else
+        faile "aggregator dup $flag_name" "rc=$rc stderr=$(tr '\n' '|' <<<"$err")"
+    fi
+done
+
+# --since duplicate (separate because it'd otherwise trip mutex with --last default).
+set +e
+since_dup_err=$("$aggregator" --since 2099-01-01 --since 2099-02-02 --scope local 2>&1 >/dev/null)
+since_dup_rc=$?
+set -e
+if [[ "$since_dup_rc" -eq 2 ]] && printf '%s' "$since_dup_err" | grep -F -q -- '--since passed more than once'; then
+    pass "aggregator rejects duplicate --since (exit 2 + named in stderr)"
+else
+    faile "aggregator dup --since" "rc=$since_dup_rc stderr=$(tr '\n' '|' <<<"$since_dup_err")"
+fi
+
+# (b) renderer: same contract on its own flags.
+for flag_pair in '--window a --window b' \
+                 '--scope local --scope global' \
+                 '--threshold-n 1 --threshold-n 99'; do
+    set +e
+    # shellcheck disable=SC2086
+    err=$(echo '' | "$renderer" $flag_pair 2>&1 >/dev/null)
+    rc=$?
+    set -e
+    case "$flag_pair" in
+        --window*) flag_name="--window" ;;
+        --scope*)  flag_name="--scope" ;;
+        --threshold-n*) flag_name="--threshold-n" ;;
+    esac
+    if [[ "$rc" -eq 2 ]] && printf '%s' "$err" | grep -F -q -- "${flag_name} passed more than once"; then
+        pass "renderer rejects duplicate $flag_name (exit 2 + named in stderr)"
+    else
+        faile "renderer dup $flag_name" "rc=$rc stderr=$(tr '\n' '|' <<<"$err")"
+    fi
+done
+
+# Single occurrence still works — regression guard so the dedup logic does
+# not accidentally treat the FIRST occurrence as "already seen".
+ok_count=$("$aggregator" --last 5 --scope local --project-root "$tmpproj" --home "$tmphome" | wc -l | tr -d ' ')
+if [[ "$ok_count" -eq 5 ]]; then
+    pass "single occurrence still works (--last 5 returns 5)"
+else
+    faile "single-flag regression" "got $ok_count want 5"
+fi
+
+# ----------------------------------------------------------------------------
+# Issue #14 — extreme --last and tail-failure surfacing
+# Two layers of defense: (1) parse-time cap rejects values bash arithmetic
+# would overflow; (2) explicit tail-exit check surfaces any future runtime
+# failure instead of silently emitting "no signal".
+# ----------------------------------------------------------------------------
+
+printf 'ISSUE-14: --last cap + tail exit surfacing\n'
+
+# (a) Out-of-range overflow value must exit 2 with a clear range message
+#     (previously: tail printed `illegal offset` to stderr but script still
+#     exited 0 with empty stdout — "quiet week" indistinguishable from a
+#     genuine no-signal run).
+set +e
+huge_err=$("$aggregator" --last 99999999999999999999 --scope local \
+    --project-root "$tmpproj" --home "$tmphome" 2>&1 >/dev/null)
+huge_rc=$?
+set -e
+if [[ "$huge_rc" -eq 2 ]]; then
+    pass "--last 99999999999999999999 exits 2 (parse-time cap)"
+else
+    faile "ISSUE-14 overflow rc" "got $huge_rc want 2 — bash arithmetic likely silently failed"
+fi
+if printf '%s' "$huge_err" | grep -qE 'too large|≤ 1000000|<= 1000000'; then
+    pass "--last overflow error names the cap (1000000)"
+else
+    faile "ISSUE-14 overflow message" "stderr did not name the 1000000 cap: $(tr '\n' '|' <<<"$huge_err")"
+fi
+
+# (b) Just-over-cap (1000001) must also exit 2.
+set +e
+"$aggregator" --last 1000001 --scope local --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+over_rc=$?
+set -e
+if [[ "$over_rc" -eq 2 ]]; then
+    pass "--last 1000001 exits 2 (cap is exclusive of 1000001)"
+else
+    faile "ISSUE-14 cap+1" "got $over_rc want 2"
+fi
+
+# (c) At-cap (1000000) must succeed (boundary regression guard).
+set +e
+"$aggregator" --last 1000000 --scope local --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+at_cap_rc=$?
+set -e
+if [[ "$at_cap_rc" -eq 0 ]]; then
+    pass "--last 1000000 succeeds (cap is inclusive of 1000000)"
+else
+    faile "ISSUE-14 at-cap" "got $at_cap_rc want 0"
+fi
+
+# (d) Pipeline empty-output sanity: --last with extreme value must NOT produce
+#     a "looks-like-success but empty stdout" pipeline. Confirms that the
+#     parse-time cap fires BEFORE the renderer ever sees the empty stream.
+set +e
+set +o pipefail
+huge_pipe_out=$( "$aggregator" --last 99999999999999999999 --scope local \
+    --project-root "$tmpproj" --home "$tmphome" 2>/dev/null \
+    | "$renderer" --window all --scope local 2>/dev/null )
+set -o pipefail
+set -e
+# Renderer always emits a header even on empty stdin, so empty pipe is
+# expected; the critical check is that the aggregator's exit 2 is not
+# masked. We re-run with pipefail to verify pipe rc.
+set +e
+( "$aggregator" --last 99999999999999999999 --scope local \
+    --project-root "$tmpproj" --home "$tmphome" 2>/dev/null \
+    | "$renderer" --window all --scope local >/dev/null 2>&1 )
+huge_pipe_rc=$?
+set -e
+if [[ "$huge_pipe_rc" -ne 0 ]]; then
+    pass "extreme --last propagates non-zero exit through pipefail (rc=$huge_pipe_rc)"
+else
+    faile "ISSUE-14 pipe propagation" "rc=0 — aggregator failure was masked"
+fi
+
+# Silence shellcheck about huge_pipe_out — it exists only to demonstrate the
+# pre-pipefail capture path; the assertion lives in huge_pipe_rc above.
+: "$huge_pipe_out"
+
+# ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------
 
 if [[ "$fail" -eq 0 ]]; then
-    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-15)\n'
+    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-9/14/15)\n'
     exit 0
 else
     printf '\ntest-dogfood-digest: FAIL\n'

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -24,10 +24,16 @@
 #   -h | --help          print usage
 # Output: Markdown on stdout.
 #
+# Each named flag may appear at most once; passing the same flag twice exits 2
+# (issue #9). Without this check, a wrapper concatenating user flags with its
+# own defaults would silently see "last value wins" — e.g.
+# `--threshold-n 1 --threshold-n 99` would suppress signal a caller intended
+# to surface.
+#
 # Exit codes:
 #   0  success (including empty or no-signal input)
 #   1  runtime failure (jq pipeline error, etc.)
-#   2  argument error
+#   2  argument error (unknown flag, duplicate flag, bad value, mktemp failure)
 #
 # Runtime: bash + jq. No Python / Node.
 
@@ -61,17 +67,35 @@ window_label=""
 scope_label="both"
 threshold_n=3
 
+# Track per-flag occurrence so `--threshold-n 1 --threshold-n 99` no longer
+# silently overwrites the first value (issue #9). Mirrors the aggregator's
+# dedup contract so wrappers see the same shape on both halves of a pipeline.
+saw_window=0
+saw_scope=0
+saw_threshold_n=0
+
+reject_duplicate() {
+    printf 'render: %s passed more than once — pass it at most once\n' "$1" >&2
+    exit 2
+}
+
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --window)
+            [[ "$saw_window" -eq 1 ]] && reject_duplicate --window
+            saw_window=1
             window_label="${2:-}"
             shift 2 || { printf 'render: --window requires a value\n' >&2; exit 2; }
             ;;
         --scope)
+            [[ "$saw_scope" -eq 1 ]] && reject_duplicate --scope
+            saw_scope=1
             scope_label="${2:-}"
             shift 2 || { printf 'render: --scope requires a value\n' >&2; exit 2; }
             ;;
         --threshold-n)
+            [[ "$saw_threshold_n" -eq 1 ]] && reject_duplicate --threshold-n
+            saw_threshold_n=1
             threshold_n="${2:-}"
             shift 2 || { printf 'render: --threshold-n requires a value\n' >&2; exit 2; }
             ;;

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -51,10 +51,14 @@ Flags:
   --scope SCOPE       local | global | both (default both); validated, mirrors
                       the aggregator's contract so the YAML frontmatter cannot
                       carry an out-of-domain label
-  --threshold-n N     positive integer; minimum observation count for threshold
-                      suggestions (default: 3; lower values mean quieter logs
-                      still emit)
+  --threshold-n N     positive integer in [1, 1000000]; minimum observation
+                      count for threshold suggestions (default: 3; lower values
+                      mean quieter logs still emit)
   -h | --help         print usage
+
+Constraints:
+  --threshold-n is a positive integer in [1, 1000000]; out-of-range → exit 2.
+  Each named flag may appear at most once (duplicate → exit 2).
 
 Exit codes:
   0 — success (including empty or no-signal input)
@@ -137,8 +141,25 @@ case "$scope_label" in
         ;;
 esac
 
-if ! [[ "$threshold_n" =~ ^[0-9]+$ ]] || [[ "$threshold_n" -le 0 ]]; then
+if ! [[ "$threshold_n" =~ ^[0-9]+$ ]]; then
     printf 'render: --threshold-n expects a positive integer (got: %s)\n' "$threshold_n" >&2
+    exit 2
+fi
+# Length-bound BEFORE arithmetic, mirroring the aggregator's --last guard
+# (issue #14 hardening). Without this, --threshold-n 99999999999999999999
+# overflows bash's signed-64-bit `[[ -le 0 ]]` compare and the value flows
+# into every `[[ qa_count -ge threshold_n ]]` test as a number too large for
+# any real signal — every section collapses to "no signal in window" with
+# exit 0, exactly the silent-empty-report failure issue #14 was meant to
+# close, just on a sibling flag. Cap is 1_000_000 (7 digits) to match the
+# aggregator's --last contract; both are observation-count knobs.
+if [[ ${#threshold_n} -gt 7 ]]; then
+    printf 'render: --threshold-n must be a positive integer <= 1000000 (got: %s)\n' "$threshold_n" >&2
+    exit 2
+fi
+threshold_n=$((10#$threshold_n))
+if [[ "$threshold_n" -le 0 ]] || [[ "$threshold_n" -gt 1000000 ]]; then
+    printf 'render: --threshold-n must be a positive integer <= 1000000 (got: %s)\n' "$threshold_n" >&2
     exit 2
 fi
 

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -86,19 +86,22 @@ reject_duplicate() {
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --window)
-            [[ "$saw_window" -eq 1 ]] && reject_duplicate --window
+            # `if [[ ]]; then …; fi` (not `[[ ]] && …`) so a future `set -e`
+            # cannot abort on the first occurrence (residual risk from PR
+            # #24 ce-review). Mirrors the aggregator's dedup pattern.
+            if [[ "$saw_window" -eq 1 ]]; then reject_duplicate --window; fi
             saw_window=1
             window_label="${2:-}"
             shift 2 || { printf 'render: --window requires a value\n' >&2; exit 2; }
             ;;
         --scope)
-            [[ "$saw_scope" -eq 1 ]] && reject_duplicate --scope
+            if [[ "$saw_scope" -eq 1 ]]; then reject_duplicate --scope; fi
             saw_scope=1
             scope_label="${2:-}"
             shift 2 || { printf 'render: --scope requires a value\n' >&2; exit 2; }
             ;;
         --threshold-n)
-            [[ "$saw_threshold_n" -eq 1 ]] && reject_duplicate --threshold-n
+            if [[ "$saw_threshold_n" -eq 1 ]]; then reject_duplicate --threshold-n; fi
             saw_threshold_n=1
             threshold_n="${2:-}"
             shift 2 || { printf 'render: --threshold-n requires a value\n' >&2; exit 2; }

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -118,39 +118,42 @@ reject_duplicate() {
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --last)
-            [[ "$saw_last" -eq 1 ]] && reject_duplicate --last
+            if [[ "$saw_last" -eq 1 ]]; then reject_duplicate --last; fi
             saw_last=1
             window_mode="last"
             window_last="${2:-}"
             shift 2 || { printf 'dogfood-digest: --last requires a value\n' >&2; exit 2; }
             ;;
         --since)
-            [[ "$saw_since" -eq 1 ]] && reject_duplicate --since
+            # `if [[ ]]; then …; fi` (not `[[ ]] && …`) so a future `set -e`
+            # cannot abort on the first occurrence — pattern repeats across
+            # every dedup'd flag (residual risk from PR #24 ce-review).
+            if [[ "$saw_since" -eq 1 ]]; then reject_duplicate --since; fi
             saw_since=1
             window_mode="since"
             window_since="${2:-}"
             shift 2 || { printf 'dogfood-digest: --since requires a value\n' >&2; exit 2; }
             ;;
         --all)
-            [[ "$saw_all" -eq 1 ]] && reject_duplicate --all
+            if [[ "$saw_all" -eq 1 ]]; then reject_duplicate --all; fi
             saw_all=1
             window_mode="all"
             shift
             ;;
         --scope)
-            [[ "$saw_scope" -eq 1 ]] && reject_duplicate --scope
+            if [[ "$saw_scope" -eq 1 ]]; then reject_duplicate --scope; fi
             saw_scope=1
             scope="${2:-}"
             shift 2 || { printf 'dogfood-digest: --scope requires a value\n' >&2; exit 2; }
             ;;
         --project-root)
-            [[ "$saw_project_root" -eq 1 ]] && reject_duplicate --project-root
+            if [[ "$saw_project_root" -eq 1 ]]; then reject_duplicate --project-root; fi
             saw_project_root=1
             project_root="${2:-}"
             shift 2 || { printf 'dogfood-digest: --project-root requires a value\n' >&2; exit 2; }
             ;;
         --home)
-            [[ "$saw_home" -eq 1 ]] && reject_duplicate --home
+            if [[ "$saw_home" -eq 1 ]]; then reject_duplicate --home; fi
             saw_home=1
             home_dir="${2:-}"
             shift 2 || { printf 'dogfood-digest: --home requires a value\n' >&2; exit 2; }

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -60,7 +60,10 @@ Defaults: --last 10 --scope both.
 Output: filtered JSONL on stdout, one event per line, each augmented with
 _source_path and _line back-reference fields.
 
-Mutually exclusive: --last and --since. --all overrides both.
+Constraints:
+  --last is a positive integer in [1, 1000000]; out-of-range → exit 2.
+  Each named flag may appear at most once (duplicate → exit 2).
+  --last and --since are mutually exclusive; --all overrides both.
 
 Test-only flags (not for production):
   --project-root DIR   override local log resolution root
@@ -225,8 +228,12 @@ if [[ "$window_mode" == "last" ]]; then
     # comparison, which under `set -uo pipefail` errors non-fatally and
     # leaves the bogus string to flow through to tail(1) — producing exit 0
     # with empty stdout, indistinguishable from a legitimate "no signal" run.
+    # Both branches emit the SAME message — they are the same semantic error
+    # ("out of contract"), just guarded at different stages. Two templates
+    # would force stderr scrapers to handle both; ASCII <= avoids non-UTF-8
+    # capture-pipeline corruption (PR #24 P3 #5 review).
     if [[ ${#window_last} -gt 7 ]]; then
-        printf 'dogfood-digest: --last must be a positive integer ≤ 1000000 (got: %s — too large)\n' "$window_last" >&2
+        printf 'dogfood-digest: --last must be a positive integer <= 1000000 (got: %s)\n' "$window_last" >&2
         exit 2
     fi
     # Force base-10 so values like "010" are not interpreted as octal in
@@ -235,7 +242,7 @@ if [[ "$window_mode" == "last" ]]; then
     # diverging from the value tail(1) actually receives downstream.
     window_last=$((10#$window_last))
     if [[ "$window_last" -le 0 ]] || [[ "$window_last" -gt 1000000 ]]; then
-        printf 'dogfood-digest: --last must be a positive integer ≤ 1000000 (got: %s)\n' "$window_last" >&2
+        printf 'dogfood-digest: --last must be a positive integer <= 1000000 (got: %s)\n' "$window_last" >&2
         exit 2
     fi
 fi

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -24,6 +24,15 @@
 # --last and --since are mutually exclusive — passing both is an error (exit 2).
 # --all overrides both.
 #
+# --last is capped at 1_000_000 to prevent overflow of bash's signed-64-bit
+# arithmetic; values above the cap exit 2 with an actionable error instead of
+# silently falling through to tail(1) as an illegal offset (issue #14).
+#
+# Each named flag may appear at most once; passing the same flag twice exits 2
+# (issue #9). The "last value silently wins" footgun particularly bit
+# `--scope local --scope global` callers — the report frontmatter ended up
+# carrying the wrong context.
+#
 # Env vars (CI/test only, override --project-root / --home when set):
 #   CRUCIBLE_DOGFOOD_ROOT  overrides --project-root for local log resolution
 #   CRUCIBLE_DOGFOOD_HOME  overrides --home for global mirror resolution
@@ -34,8 +43,9 @@
 #
 # Exit codes:
 #   0  success (including empty input / zero sources)
-#   1  runtime failure (jq/date/mv pipeline error)
-#   2  argument error (unknown flag, mutex violation, bad value, mktemp failure)
+#   1  runtime failure (jq/date/mv/tail pipeline error)
+#   2  argument error (unknown flag, duplicate flag, mutex violation,
+#                       bad value, mktemp failure)
 #
 # Runtime: bash (>=4) + jq (>=1.6) + date. No Python / Node.
 
@@ -81,40 +91,64 @@ scope="both"
 project_root="${PWD}"
 home_dir="${HOME}"
 
-# Track which window flags were actually passed so --last + --since can be
-# rejected per the documented mutex contract (see header comment).
+# Track which flags were actually passed. saw_last/saw_since/saw_all are also
+# consulted for the --last/--since mutex below; the rest exist solely to
+# detect duplicate flags (issue #9 — "last-value-silently-wins" across all
+# named flags poisoned wrappers that concatenated user args without dedup,
+# and silently swapped --scope between aggregator and renderer halves of a
+# pipeline).
 saw_last=0
 saw_since=0
 saw_all=0
+saw_scope=0
+saw_project_root=0
+saw_home=0
+
+# Helper: reject a duplicate occurrence of $1 by exiting 2 with an actionable
+# message. Centralised so adding a new dedup'd flag stays one line in the
+# case branch instead of duplicating the printf.
+reject_duplicate() {
+    printf 'dogfood-digest: %s passed more than once — pass it at most once\n' "$1" >&2
+    exit 2
+}
 
 while [[ $# -gt 0 ]]; do
     case "$1" in
         --last)
+            [[ "$saw_last" -eq 1 ]] && reject_duplicate --last
             saw_last=1
             window_mode="last"
             window_last="${2:-}"
             shift 2 || { printf 'dogfood-digest: --last requires a value\n' >&2; exit 2; }
             ;;
         --since)
+            [[ "$saw_since" -eq 1 ]] && reject_duplicate --since
             saw_since=1
             window_mode="since"
             window_since="${2:-}"
             shift 2 || { printf 'dogfood-digest: --since requires a value\n' >&2; exit 2; }
             ;;
         --all)
+            [[ "$saw_all" -eq 1 ]] && reject_duplicate --all
             saw_all=1
             window_mode="all"
             shift
             ;;
         --scope)
+            [[ "$saw_scope" -eq 1 ]] && reject_duplicate --scope
+            saw_scope=1
             scope="${2:-}"
             shift 2 || { printf 'dogfood-digest: --scope requires a value\n' >&2; exit 2; }
             ;;
         --project-root)
+            [[ "$saw_project_root" -eq 1 ]] && reject_duplicate --project-root
+            saw_project_root=1
             project_root="${2:-}"
             shift 2 || { printf 'dogfood-digest: --project-root requires a value\n' >&2; exit 2; }
             ;;
         --home)
+            [[ "$saw_home" -eq 1 ]] && reject_duplicate --home
+            saw_home=1
             home_dir="${2:-}"
             shift 2 || { printf 'dogfood-digest: --home requires a value\n' >&2; exit 2; }
             ;;
@@ -180,8 +214,19 @@ case "$scope" in
 esac
 
 if [[ "$window_mode" == "last" ]]; then
-    if ! [[ "$window_last" =~ ^[0-9]+$ ]] || [[ "$window_last" -le 0 ]]; then
+    if ! [[ "$window_last" =~ ^[0-9]+$ ]]; then
         printf 'dogfood-digest: --last expects a positive integer (got: %s)\n' "$window_last" >&2
+        exit 2
+    fi
+    # Length-bound the input BEFORE any bash arithmetic. The cap is 1_000_000
+    # (7 digits), so any string longer than 7 chars is out-of-range without
+    # needing to parse it. This guards against issue #14: values like
+    # `99999999999999999999` overflow bash's signed-64-bit `[[ -le 0 ]]`
+    # comparison, which under `set -uo pipefail` errors non-fatally and
+    # leaves the bogus string to flow through to tail(1) — producing exit 0
+    # with empty stdout, indistinguishable from a legitimate "no signal" run.
+    if [[ ${#window_last} -gt 7 ]]; then
+        printf 'dogfood-digest: --last must be a positive integer ≤ 1000000 (got: %s — too large)\n' "$window_last" >&2
         exit 2
     fi
     # Force base-10 so values like "010" are not interpreted as octal in
@@ -189,6 +234,10 @@ if [[ "$window_mode" == "last" ]]; then
     # octal, which causes "08"/"09" to error and "010" to silently mean 8 —
     # diverging from the value tail(1) actually receives downstream.
     window_last=$((10#$window_last))
+    if [[ "$window_last" -le 0 ]] || [[ "$window_last" -gt 1000000 ]]; then
+        printf 'dogfood-digest: --last must be a positive integer ≤ 1000000 (got: %s)\n' "$window_last" >&2
+        exit 2
+    fi
 fi
 
 # ----- cutoff resolution for --since -----------------------------------------
@@ -343,7 +392,16 @@ case "$window_mode" in
         jq -c --arg cut "$cutoff_iso" 'select((.ts // "") >= $cut)' "$tmp_raw"
         ;;
     last)
-        # Take last N lines (after sort). On BSD/GNU coreutils, tail behaves identically.
-        tail -n "$window_last" "$tmp_raw"
+        # Take last N lines (after sort). On BSD/GNU coreutils, tail behaves
+        # identically. Check tail's exit code explicitly — without `set -e`, a
+        # tail failure (e.g. internal arg-parse error from a value that snuck
+        # past the parse-time cap) would leave this case branch with exit 0
+        # and empty stdout, which the renderer indistinguishably reports as
+        # "no signal in window". The parse-time cap above already rejects
+        # extreme values; this is defense-in-depth (issue #14).
+        if ! tail -n "$window_last" "$tmp_raw"; then
+            printf 'dogfood-digest: tail failed for --last %s\n' "$window_last" >&2
+            exit 1
+        fi
         ;;
 esac

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -33,7 +33,9 @@ input: |
     --scope local|global|both   기본 both. aggregator 의 --scope 와 동일하게
                        검증되어 frontmatter 의 `scope:` 에 그대로 쓰인다.
     --threshold-n N    Threshold 섹션에서 qa_judge / axis_skip 관측수 하한
-                       (기본 3). 양의 정수만 허용.
+                       (기본 3). 양의 정수, 최대 1_000_000.
+                       범위 밖 / 비숫자는 exit 2 (PR #24 ce-review P1 — same
+                       arithmetic-overflow surface as aggregator's --last).
 
   입력 소스 (aggregator 가 resolve, renderer 는 stdin 만 읽음):
     로컬  `${CRUCIBLE_DOGFOOD_ROOT:-${PROJECT_ROOT}}/.claude/dogfood/log.jsonl`

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -10,7 +10,8 @@ input: |
   로 exit 2 한다. `--scope` 만 양쪽이 공유한다.
 
   Aggregator (`scripts/dogfood-digest.sh`) — window · scope · 경로 resolve:
-    --last N           최근 N 이벤트 (기본 10). 양의 정수.
+    --last N           최근 N 이벤트 (기본 10). 양의 정수, 최대 1_000_000.
+                       범위 밖 / 비숫자는 exit 2.
     --since DATE|Nd    절대 날짜(YYYY-MM-DD / ISO8601) 또는 상대 기간(예: 7d).
     --all              전체 window. --last/--since 조합은 error(exit 2),
                        --all 이 함께 오면 overrides.
@@ -19,10 +20,14 @@ input: |
     --home DIR         (CI/test only) $HOME 대신 사용할 글로벌 mirror 루트.
     env CRUCIBLE_DOGFOOD_ROOT  위 --project-root 보다 우선. 적용 시 stderr 에 info.
     env CRUCIBLE_DOGFOOD_HOME  위 --home 보다 우선. 적용 시 stderr 에 info.
+  같은 플래그를 두 번 패스하면 exit 2 — wrapper 가 사용자 인자를 자기
+  default 와 단순 concat 할 때 마지막 값이 조용히 이기는 footgun을 차단한다
+  (issue #9).
 
   Renderer (`scripts/dogfood-digest-render.sh`) — Markdown 변환 단계 knob.
   **`--threshold-n` 은 renderer 전용** — aggregator 에 전달하면 unknown
-  argument 로 exit 2 한다.
+  argument 로 exit 2 한다. aggregator 와 마찬가지로 같은 플래그를 두 번
+  패스하면 exit 2 (issue #9).
     --window LABEL     window 라벨(파일명 + frontmatter, 필수). 호출자가
                        aggregator 의 window 플래그에 맞춰 합성한다.
     --scope local|global|both   기본 both. aggregator 의 --scope 와 동일하게
@@ -41,8 +46,9 @@ output: |
 
   Exit codes (aggregator + renderer 공통):
     0  성공 (zero-source / zero-signal 포함)
-    1  런타임 실패 (jq/date/mv pipeline 에러)
-    2  인자 오류 (unknown flag, mutex 위반, 잘못된 값, mktemp 실패)
+    1  런타임 실패 (jq/date/mv/tail pipeline 에러)
+    2  인자 오류 (unknown flag, duplicate flag, mutex 위반, 잘못된 값,
+                  --last 범위 위반, mktemp 실패)
 validate_prompt: |
   /crucible:dogfood-digest 완료 시 자기검증 (Dogfood-Digest 4축):
   1. 산출 파일 경로가 `.claude/plans/YYYY-MM-DD-dogfood-digest-{window}.md` 규약을 만족하고 slug `[a-zA-Z0-9_-]` 화이트리스트 내인가?


### PR DESCRIPTION
## Summary

Closes #9 and #14 — two arg-parsing footguns surfaced by PR #7 ce-review (ADV-005, ADV-010). Both touch `case` arms in the aggregator and renderer, so they ride together in one PR per the original triage note.

### Issue #9 — duplicate single-flag silent overwrite

`--scope local --scope global` returned only globals while a wrapper that concatenated user args with its own `--scope local` default thought the digest was local-scoped — wrong-context attribution downstream when promotion candidates fed `/compound`. Same shape on `--last`, `--since`, `--all`, `--project-root`, `--home`, `--window`, `--threshold-n`.

**Fix**: per-flag `saw_X` tracking + `reject_duplicate()` helper that exits 2 with the offending flag name in stderr.

### Issue #14 — extreme `--last` masked as "no signal"

`--last 99999999999999999999` overflowed bash's signed-64-bit `[[ -le 0 ]]` comparison, errored non-fatally under `set -uo pipefail`, and reached `tail` as an illegal offset. tail's stderr complaint was preserved but the script exited 0 with empty stdout — indistinguishable from a legitimate "no signal" run.

**Fix**: two layers
1. **Parse-time cap**: length-bound `--last` to 7 digits *before* any bash arithmetic (avoids overflow), then numeric cap at 1_000_000.
2. **Explicit tail exit check**: any runtime tail failure surfaces as exit 1 instead of being swallowed.

## Files

| File | Change |
|---|---|
| `scripts/dogfood-digest.sh` | dedup + --last cap + tail exit check |
| `scripts/dogfood-digest-render.sh` | dedup |
| `skills/dogfood-digest/SKILL.md` | document new contracts in `input:` and `output:` |
| `__tests__/integration/test-dogfood-digest.sh` | ISSUE-9 block (9 dup cases) + ISSUE-14 block (overflow / cap / boundary / pipe propagation) |

## Test plan

- [x] `bash __tests__/integration/test-dogfood-digest.sh` — ALL PASS (existing SC-1~7, ADV-003/006/007/008, ISSUE-15 still green; new ISSUE-9 and ISSUE-14 blocks added)
- [x] No new `shellcheck` warnings (existing SC2094/SC2016 info-level warnings predate this PR)
- [x] Other integration tests (`test-ac2/3/4/6`, `test-dogfood-log`, `test-ac-issue13-stale-tempfile-cleanup`) unchanged
- [x] `--last 1000000` (at cap) still works; `--last 1000001` (cap+1) exits 2

## Boundary table (issue #14)

| `--last` value | Before | After |
|---|---|---|
| 5 | OK | OK |
| 1000000 | OK | OK (cap is inclusive) |
| 1000001 | OK | exit 2 |
| 99999999999999999999 | exit 0 + empty stdout (silent failure) | exit 2 with cap message |

## Out of scope

PR-B (#16 + #17 + #18 — stderr UX polish, exit-code split, severity prefixes) and PR-C (#19 — JSON output mode) follow as separate PRs to keep this one bounded.