### PR TITLE
feat(digest): stderr UX polish — severity prefix + exit codes + warn rate-limit (issues #16, #17, #18)

### DIFF
--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -835,16 +835,17 @@ if [[ "$i15_rc" -eq 2 ]]; then
 else
     faile "issue-15 exit code" "expected 2, got $i15_rc"
 fi
-# Anchor on the targeted-hint discriminator (`hint —` AND `render-time flag`)
-# so deleting the case "$1" in --window|--threshold-n) block in
+# Anchor on the targeted-hint discriminator (`info: hint:` AND `render-time
+# flag`) so deleting the case "$1" in --window|--threshold-n) block in
 # scripts/dogfood-digest.sh actually breaks this assertion. The bare string
 # "dogfood-digest-render.sh" was satisfied by the print_help cross-reference
 # alone (see codex review on pr #21) — the assertion would have stayed green
-# even with the targeted hint removed.
-if grep -q 'hint —' "$i15_stderr" && grep -q 'is a render-time flag' "$i15_stderr"; then
+# even with the targeted hint removed. Format updated to severity-prefix
+# scheme (issue #16): `info: hint:` replaces the old `hint —` em-dash.
+if grep -F -q -- 'info: hint:' "$i15_stderr" && grep -q 'is a render-time flag' "$i15_stderr"; then
     pass "aggregator stderr emits targeted misroute hint on --threshold-n"
 else
-    faile "issue-15 stderr hint" "expected 'hint —' and 'is a render-time flag' in stderr; got: $(tr '\n' '|' < "$i15_stderr")"
+    faile "issue-15 stderr hint" "expected 'info: hint:' and 'is a render-time flag' in stderr; got: $(tr '\n' '|' < "$i15_stderr")"
 fi
 # Hint must reference the renderer script by name so a naive agent can
 # self-recover without re-reading the help text.
@@ -1233,11 +1234,243 @@ else
 fi
 
 # ----------------------------------------------------------------------------
+# Issue #16 — exit-code split + uniform stderr severity tagging
+# Arg errors stay at exit 2 (recoverable, retry with fixed args). System
+# errors (mktemp on full /tmp, missing tools) move to exit 3 (escalate, do
+# not retry). Every stderr line is prefixed `<script>: <severity>: <msg>`
+# where severity ∈ {info, warn, error}. Without uniform tagging, agents
+# cannot keyword-match severity without parsing free-form prose.
+# ----------------------------------------------------------------------------
+
+printf 'ISSUE-16: severity prefixes + arg/system exit-code split\n'
+
+# (a) Every fatal stderr line carries `error:` severity.
+for case in '--bogus-flag' '--last 0' '--last 99999999999999999999' \
+            '--last 5 --since 7d' '--since 99999d' '--since 2099-01-01T00:00:00+09:00' \
+            '--scope bogus'; do
+    set +e
+    # shellcheck disable=SC2086
+    err_out=$("$aggregator" $case --project-root "$tmpproj" --home "$tmphome" 2>&1 >/dev/null)
+    set -e
+    if printf '%s' "$err_out" | grep -F -q -- 'dogfood-digest: error:'; then
+        pass "agg fatal stderr ($case) carries 'error:' severity prefix"
+    else
+        faile "agg severity prefix on $case" "stderr=$(tr '\n' '|' <<<"$err_out")"
+    fi
+done
+
+# Renderer fatal stderr also carries `error:` severity.
+for case in '--bogus-flag' '--threshold-n 0' '--threshold-n 99999999999999999999' \
+            '--scope bogus'; do
+    set +e
+    # shellcheck disable=SC2086
+    err_out=$(echo '' | "$renderer" --window t $case 2>&1 >/dev/null)
+    set -e
+    if printf '%s' "$err_out" | grep -F -q -- 'render: error:'; then
+        pass "render fatal stderr ($case) carries 'error:' severity prefix"
+    else
+        faile "render severity prefix on $case" "stderr=$(tr '\n' '|' <<<"$err_out")"
+    fi
+done
+
+# (b) mktemp failure routes to exit 3 (system error) instead of exit 2
+# (arg error). Force mktemp failure by pointing TMPDIR at a non-existent
+# directory and using a fixture that produces enough output to require
+# tempfile creation (otherwise zero-source path exits 0 before mktemp runs).
+mkdir_proj="$(mktemp -d -t dfd-mktemp.XXXXXX)"
+mkdir -p "$mkdir_proj/.claude/dogfood"
+cp "$fixture" "$mkdir_proj/.claude/dogfood/log.jsonl"
+
+set +e
+mktemp_err=$(TMPDIR=/no/such/dir/ever "$aggregator" --all --scope local \
+    --project-root "$mkdir_proj" --home "$tmphome" 2>&1 >/dev/null)
+mktemp_rc=$?
+set -e
+# Some shells/mktemp implementations may still succeed if /tmp is reachable
+# via a fallback. Accept exit 3 OR a clean run (rc=0) — but if it errors,
+# it MUST be exit 3, never exit 2. The latter would mean a system error
+# was misclassified as recoverable.
+if [[ "$mktemp_rc" -eq 3 ]]; then
+    pass "mktemp failure routes to exit 3 (system error)"
+    if printf '%s' "$mktemp_err" | grep -F -q -- 'system error'; then
+        pass "mktemp error message names 'system error' (escalation hint)"
+    else
+        faile "mktemp escalation hint" "stderr=$(tr '\n' '|' <<<"$mktemp_err")"
+    fi
+elif [[ "$mktemp_rc" -eq 2 ]]; then
+    faile "mktemp exit-code class" "got rc=2 (arg error) — expected rc=3 (system error)"
+else
+    pass "mktemp succeeded via fallback (rc=$mktemp_rc) — system path not exercised on this env"
+fi
+
+# Renderer mktemp also routes to exit 3.
+set +e
+TMPDIR=/no/such/dir/ever echo '' | "$renderer" --window t --scope local >/dev/null 2>&1
+ren_mktemp_rc=$?
+set -e
+# Renderer always creates a tempfile, so this almost always exercises mktemp.
+if [[ "$ren_mktemp_rc" -eq 3 ]]; then
+    pass "render mktemp failure routes to exit 3"
+elif [[ "$ren_mktemp_rc" -eq 2 ]]; then
+    faile "render mktemp exit-code" "got rc=2 — expected rc=3 (system error)"
+else
+    pass "render mktemp succeeded via fallback (rc=$ren_mktemp_rc) — system path not exercised"
+fi
+
+rm -rf "$mkdir_proj"
+
+# (c) Arg-error sites still emit exit 2 (regression guard). The split must
+# only move mktemp; everything else stays at exit 2.
+for case in '--bogus-flag' '--last 0' '--last 99999999999999999999' \
+            '--scope bogus' '--last 5 --since 7d'; do
+    set +e
+    # shellcheck disable=SC2086
+    "$aggregator" $case --project-root "$tmpproj" --home "$tmphome" >/dev/null 2>&1
+    rc=$?
+    set -e
+    if [[ "$rc" -eq 2 ]]; then
+        pass "arg error ($case) stays at exit 2"
+    else
+        faile "arg-vs-system split on $case" "got rc=$rc want 2"
+    fi
+done
+
+# ----------------------------------------------------------------------------
+# Issue #17 — per-row malformed-line warn rate-limit
+# First 5 malformed rows per source emit verbatim `warn:` lines. Anything
+# beyond that gets folded into a single `N more malformed rows skipped`
+# summary line. Without the cap, a corrupted JSONL with thousands of bad
+# rows blew downstream agent context budgets and trained agents to ignore
+# stderr entirely.
+# ----------------------------------------------------------------------------
+
+printf 'ISSUE-17: warn rate-limit per source\n'
+
+flood_proj="$(mktemp -d -t dfd-flood.XXXXXX)"
+mkdir -p "$flood_proj/.claude/dogfood"
+# Generate 12 malformed rows + 2 valid rows. Cap is 5, so we expect 5
+# verbatim warn lines + 1 summary line ("7 more malformed rows skipped").
+{
+    for i in $(seq 1 7); do
+        echo "BAD_ROW_${i}_NOT_JSON"
+    done
+    echo '{"ts":"2026-04-25T00:00:00Z","type":"note","category":"pain","text":"valid"}'
+    for i in $(seq 8 12); do
+        echo "BAD_ROW_${i}_NOT_JSON"
+    done
+    echo '{"ts":"2026-04-25T00:00:01Z","type":"note","category":"good","text":"valid"}'
+} > "$flood_proj/.claude/dogfood/log.jsonl"
+
+set +e
+flood_stderr=$("$aggregator" --all --scope local --project-root "$flood_proj" \
+    --home "$tmphome" 2>&1 >/dev/null)
+set -e
+
+verbatim_count=$(printf '%s\n' "$flood_stderr" | grep -c 'warn: skipping malformed row' || true)
+summary_count=$(printf '%s\n' "$flood_stderr" | grep -c 'more malformed rows skipped' || true)
+
+if [[ "$verbatim_count" -eq 5 ]]; then
+    pass "warn cap honoured: exactly 5 verbatim 'warn: skipping' lines (got $verbatim_count)"
+else
+    faile "warn cap" "got $verbatim_count verbatim warn lines, want 5"
+fi
+if [[ "$summary_count" -eq 1 ]]; then
+    pass "warn summary line emitted exactly once"
+else
+    faile "warn summary count" "got $summary_count summary lines, want 1"
+fi
+# 12 bad rows total, 5 emitted verbatim → 7 folded.
+if printf '%s' "$flood_stderr" | grep -F -q -- '7 more malformed rows skipped'; then
+    pass "warn summary names the correct fold count (7)"
+else
+    faile "warn summary count value" "expected '7 more malformed rows skipped', stderr=$(tr '\n' '|' <<<"$flood_stderr")"
+fi
+# Valid rows must still survive — the flood doesn't drop downstream data.
+flood_count=$("$aggregator" --all --scope local --project-root "$flood_proj" \
+    --home "$tmphome" 2>/dev/null | wc -l | tr -d ' ')
+if [[ "$flood_count" -eq 2 ]]; then
+    pass "warn rate-limit doesn't drop valid rows (2 valid survive flood of 12 bad)"
+else
+    faile "flood survivorship" "got $flood_count valid rows want 2"
+fi
+rm -rf "$flood_proj"
+
+# Below-cap case: 3 bad rows (under cap=5) emit 3 verbatim warn lines and
+# zero summary line. Pins the boundary so a future off-by-one regresses.
+under_proj="$(mktemp -d -t dfd-under.XXXXXX)"
+mkdir -p "$under_proj/.claude/dogfood"
+{
+    echo 'BAD_1'
+    echo '{"ts":"2026-04-25T00:00:00Z","type":"note","category":"pain","text":"a"}'
+    echo 'BAD_2'
+    echo 'BAD_3'
+} > "$under_proj/.claude/dogfood/log.jsonl"
+set +e
+under_stderr=$("$aggregator" --all --scope local --project-root "$under_proj" \
+    --home "$tmphome" 2>&1 >/dev/null)
+set -e
+under_verbatim=$(printf '%s\n' "$under_stderr" | grep -c 'warn: skipping malformed row' || true)
+under_summary=$(printf '%s\n' "$under_stderr" | grep -c 'more malformed rows skipped' || true)
+if [[ "$under_verbatim" -eq 3 && "$under_summary" -eq 0 ]]; then
+    pass "below-cap (3 bad rows) emits 3 verbatim, 0 summary"
+else
+    faile "below-cap behavior" "verbatim=$under_verbatim summary=$under_summary want 3/0"
+fi
+rm -rf "$under_proj"
+
+# ----------------------------------------------------------------------------
+# Issue #18 — CRUCIBLE_DOGFOOD_QUIET_OVERRIDE suppresses env-override info
+# CI runs that legitimately set CRUCIBLE_DOGFOOD_ROOT/HOME on every
+# invocation can opt into silence so the info-line noise doesn't push
+# agents toward "ignore stderr entirely" (masking the warn/error lines
+# that DO matter).
+# ----------------------------------------------------------------------------
+
+printf 'ISSUE-18: CRUCIBLE_DOGFOOD_QUIET_OVERRIDE\n'
+
+# Default behavior: env override produces a stderr info line.
+default_stderr=$(CRUCIBLE_DOGFOOD_ROOT="$tmpproj" "$aggregator" --all --scope local \
+    --project-root "/some/other/path" --home "$tmphome" 2>&1 >/dev/null)
+if printf '%s' "$default_stderr" | grep -F -q -- 'info: CRUCIBLE_DOGFOOD_ROOT='; then
+    pass "default: env-override info line emitted"
+else
+    faile "default info emit" "stderr=$(tr '\n' '|' <<<"$default_stderr")"
+fi
+
+# Opt-in: CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1 suppresses the info line.
+quiet_stderr=$(CRUCIBLE_DOGFOOD_ROOT="$tmpproj" CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1 \
+    "$aggregator" --all --scope local --project-root "/some/other/path" --home "$tmphome" 2>&1 >/dev/null)
+if ! printf '%s' "$quiet_stderr" | grep -F -q -- 'CRUCIBLE_DOGFOOD_ROOT'; then
+    pass "QUIET_OVERRIDE=1 suppresses env-override info line"
+else
+    faile "QUIET_OVERRIDE suppression" "stderr should be empty on info, got: $(tr '\n' '|' <<<"$quiet_stderr")"
+fi
+
+# QUIET_OVERRIDE must NOT suppress warn or error severity. A bad-flag
+# invocation under QUIET_OVERRIDE=1 must still emit the error line —
+# otherwise the opt-in would silently mask real failures.
+quiet_err_stderr=$(CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1 "$aggregator" --bogus-flag 2>&1 >/dev/null || true)
+if printf '%s' "$quiet_err_stderr" | grep -F -q -- 'error: unknown argument'; then
+    pass "QUIET_OVERRIDE=1 does NOT suppress error: severity (error still emitted)"
+else
+    faile "QUIET_OVERRIDE error scope" "stderr=$(tr '\n' '|' <<<"$quiet_err_stderr")"
+fi
+
+# QUIET_OVERRIDE=0 (explicit) behaves like default — info still emits.
+explicit0_stderr=$(CRUCIBLE_DOGFOOD_ROOT="$tmpproj" CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=0 \
+    "$aggregator" --all --scope local --project-root "/some/other/path" --home "$tmphome" 2>&1 >/dev/null)
+if printf '%s' "$explicit0_stderr" | grep -F -q -- 'info: CRUCIBLE_DOGFOOD_ROOT='; then
+    pass "QUIET_OVERRIDE=0 keeps default behavior (info emitted)"
+else
+    faile "QUIET_OVERRIDE=0" "stderr=$(tr '\n' '|' <<<"$explicit0_stderr")"
+fi
+
+# ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------
 
 if [[ "$fail" -eq 0 ]]; then
-    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-9/14/15 + 14-mirror + help-constraints)\n'
+    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-9/14/15/16/17/18 + 14-mirror + help-constraints)\n'
     exit 0
 else
     printf '\ntest-dogfood-digest: FAIL\n'

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -1304,8 +1304,12 @@ else
 fi
 
 # Renderer mktemp also routes to exit 3.
+# CRITICAL: `TMPDIR=val cmd1 | cmd2` scopes TMPDIR to cmd1 only (bash
+# pipeline env-var rule). Putting it before `echo` would set TMPDIR for
+# echo, not the renderer, and the renderer would inherit the parent's
+# TMPDIR — never exercising the exit-3 path. Set it on the renderer side.
 set +e
-TMPDIR=/no/such/dir/ever echo '' | "$renderer" --window t --scope local >/dev/null 2>&1
+echo '' | TMPDIR=/no/such/dir/ever "$renderer" --window t --scope local >/dev/null 2>&1
 ren_mktemp_rc=$?
 set -e
 # Renderer always creates a tempfile, so this almost always exercises mktemp.
@@ -1346,16 +1350,28 @@ done
 
 printf 'ISSUE-17: warn rate-limit per source\n'
 
+# Derive WARN_CAP from the aggregator script so a future cap change in
+# scripts/dogfood-digest.sh doesn't silently break four hardcoded test
+# assertions (was: literal `5` and derived `7` baked across the block).
+WARN_CAP=$(grep -E '^readonly WARN_CAP=' "$aggregator" | head -1 | cut -d= -f2)
+if ! [[ "$WARN_CAP" =~ ^[0-9]+$ ]] || [[ "$WARN_CAP" -lt 1 ]]; then
+    faile "issue-17 setup" "WARN_CAP could not be derived from aggregator (got: $WARN_CAP)"
+    WARN_CAP=5  # fallback so subsequent assertions still execute
+fi
+
 flood_proj="$(mktemp -d -t dfd-flood.XXXXXX)"
 mkdir -p "$flood_proj/.claude/dogfood"
-# Generate 12 malformed rows + 2 valid rows. Cap is 5, so we expect 5
-# verbatim warn lines + 1 summary line ("7 more malformed rows skipped").
+# Generate (WARN_CAP + 7) malformed rows + 2 valid rows. With cap=5 by
+# default that's 12 bad / 2 valid; expect WARN_CAP verbatim warn lines
+# + 1 summary line naming the fold count (7 when cap=5).
+flood_bad_total=$((WARN_CAP + 7))
+flood_fold_count=$((flood_bad_total - WARN_CAP))
 {
     for i in $(seq 1 7); do
         echo "BAD_ROW_${i}_NOT_JSON"
     done
     echo '{"ts":"2026-04-25T00:00:00Z","type":"note","category":"pain","text":"valid"}'
-    for i in $(seq 8 12); do
+    for i in $(seq 8 "$flood_bad_total"); do
         echo "BAD_ROW_${i}_NOT_JSON"
     done
     echo '{"ts":"2026-04-25T00:00:01Z","type":"note","category":"good","text":"valid"}'
@@ -1369,21 +1385,21 @@ set -e
 verbatim_count=$(printf '%s\n' "$flood_stderr" | grep -c 'warn: skipping malformed row' || true)
 summary_count=$(printf '%s\n' "$flood_stderr" | grep -c 'more malformed rows skipped' || true)
 
-if [[ "$verbatim_count" -eq 5 ]]; then
-    pass "warn cap honoured: exactly 5 verbatim 'warn: skipping' lines (got $verbatim_count)"
+if [[ "$verbatim_count" -eq "$WARN_CAP" ]]; then
+    pass "warn cap honoured: exactly $WARN_CAP verbatim 'warn: skipping' lines (got $verbatim_count)"
 else
-    faile "warn cap" "got $verbatim_count verbatim warn lines, want 5"
+    faile "warn cap" "got $verbatim_count verbatim warn lines, want $WARN_CAP"
 fi
 if [[ "$summary_count" -eq 1 ]]; then
     pass "warn summary line emitted exactly once"
 else
     faile "warn summary count" "got $summary_count summary lines, want 1"
 fi
-# 12 bad rows total, 5 emitted verbatim → 7 folded.
-if printf '%s' "$flood_stderr" | grep -F -q -- '7 more malformed rows skipped'; then
-    pass "warn summary names the correct fold count (7)"
+# (WARN_CAP + 7) bad rows total, WARN_CAP emitted verbatim → 7 folded.
+if printf '%s' "$flood_stderr" | grep -F -q -- "$flood_fold_count more malformed rows skipped"; then
+    pass "warn summary names the correct fold count ($flood_fold_count)"
 else
-    faile "warn summary count value" "expected '7 more malformed rows skipped', stderr=$(tr '\n' '|' <<<"$flood_stderr")"
+    faile "warn summary count value" "expected '$flood_fold_count more malformed rows skipped', stderr=$(tr '\n' '|' <<<"$flood_stderr")"
 fi
 # Valid rows must still survive — the flood doesn't drop downstream data.
 flood_count=$("$aggregator" --all --scope local --project-root "$flood_proj" \
@@ -1395,15 +1411,20 @@ else
 fi
 rm -rf "$flood_proj"
 
-# Below-cap case: 3 bad rows (under cap=5) emit 3 verbatim warn lines and
-# zero summary line. Pins the boundary so a future off-by-one regresses.
+# Below-cap case: (WARN_CAP - 2) bad rows emit (WARN_CAP - 2) verbatim
+# warn lines and zero summary line. Pins the boundary so a future
+# off-by-one regresses.
+under_bad_total=$((WARN_CAP - 2))
+if [[ "$under_bad_total" -lt 1 ]]; then
+    under_bad_total=1  # cap < 3 makes the boundary degenerate; floor at 1
+fi
 under_proj="$(mktemp -d -t dfd-under.XXXXXX)"
 mkdir -p "$under_proj/.claude/dogfood"
 {
-    echo 'BAD_1'
+    for i in $(seq 1 "$under_bad_total"); do
+        echo "BAD_${i}"
+    done
     echo '{"ts":"2026-04-25T00:00:00Z","type":"note","category":"pain","text":"a"}'
-    echo 'BAD_2'
-    echo 'BAD_3'
 } > "$under_proj/.claude/dogfood/log.jsonl"
 set +e
 under_stderr=$("$aggregator" --all --scope local --project-root "$under_proj" \
@@ -1411,12 +1432,38 @@ under_stderr=$("$aggregator" --all --scope local --project-root "$under_proj" \
 set -e
 under_verbatim=$(printf '%s\n' "$under_stderr" | grep -c 'warn: skipping malformed row' || true)
 under_summary=$(printf '%s\n' "$under_stderr" | grep -c 'more malformed rows skipped' || true)
-if [[ "$under_verbatim" -eq 3 && "$under_summary" -eq 0 ]]; then
-    pass "below-cap (3 bad rows) emits 3 verbatim, 0 summary"
+if [[ "$under_verbatim" -eq "$under_bad_total" && "$under_summary" -eq 0 ]]; then
+    pass "below-cap ($under_bad_total bad rows, cap=$WARN_CAP) emits $under_bad_total verbatim, 0 summary"
 else
-    faile "below-cap behavior" "verbatim=$under_verbatim summary=$under_summary want 3/0"
+    faile "below-cap behavior" "verbatim=$under_verbatim summary=$under_summary want $under_bad_total/0"
 fi
 rm -rf "$under_proj"
+
+# Singular-noun boundary: when fold count == 1, summary must read
+# "1 more malformed row skipped" (singular "row"), not "1 more
+# malformed rows skipped" (plural noun + singular subject mismatch).
+# Construct (WARN_CAP + 1) bad rows so exactly 1 row is folded.
+singular_bad_total=$((WARN_CAP + 1))
+sing_proj="$(mktemp -d -t dfd-sing.XXXXXX)"
+mkdir -p "$sing_proj/.claude/dogfood"
+{
+    for i in $(seq 1 "$singular_bad_total"); do
+        echo "BAD_${i}"
+    done
+    echo '{"ts":"2026-04-25T00:00:00Z","type":"note","category":"pain","text":"a"}'
+} > "$sing_proj/.claude/dogfood/log.jsonl"
+set +e
+sing_stderr=$("$aggregator" --all --scope local --project-root "$sing_proj" \
+    --home "$tmphome" 2>&1 >/dev/null)
+set -e
+if printf '%s' "$sing_stderr" | grep -F -q -- '1 more malformed row skipped'; then
+    pass "warn summary uses singular 'row' when fold count == 1"
+elif printf '%s' "$sing_stderr" | grep -F -q -- '1 more malformed rows skipped'; then
+    faile "warn summary plural-noun bug" "got '1 more malformed rows skipped' (plural noun + singular subject)"
+else
+    faile "warn summary singular case" "no '1 more malformed' line in: $(tr '\n' '|' <<<"$sing_stderr")"
+fi
+rm -rf "$sing_proj"
 
 # ----------------------------------------------------------------------------
 # Issue #18 — CRUCIBLE_DOGFOOD_QUIET_OVERRIDE suppresses env-override info
@@ -1464,6 +1511,44 @@ if printf '%s' "$explicit0_stderr" | grep -F -q -- 'info: CRUCIBLE_DOGFOOD_ROOT=
 else
     faile "QUIET_OVERRIDE=0" "stderr=$(tr '\n' '|' <<<"$explicit0_stderr")"
 fi
+
+# QUIET_OVERRIDE must apply symmetrically to the HOME branch, not just
+# ROOT. Without this, a future refactor splitting the two guards could
+# silently leak HOME info while ROOT stays suppressed.
+home_default_stderr=$(CRUCIBLE_DOGFOOD_HOME="$tmphome" "$aggregator" --all \
+    --scope local --project-root "$tmpproj" --home "/some/other/home" 2>&1 >/dev/null)
+if printf '%s' "$home_default_stderr" | grep -F -q -- 'info: CRUCIBLE_DOGFOOD_HOME='; then
+    pass "default: HOME env-override info line emitted"
+else
+    faile "default HOME info" "stderr=$(tr '\n' '|' <<<"$home_default_stderr")"
+fi
+home_quiet_stderr=$(CRUCIBLE_DOGFOOD_HOME="$tmphome" CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1 \
+    "$aggregator" --all --scope local --project-root "$tmpproj" --home "/some/other/home" 2>&1 >/dev/null)
+if ! printf '%s' "$home_quiet_stderr" | grep -F -q -- 'CRUCIBLE_DOGFOOD_HOME'; then
+    pass "QUIET_OVERRIDE=1 suppresses HOME env-override info line (symmetric with ROOT)"
+else
+    faile "QUIET_OVERRIDE HOME suppression" "stderr should be empty on info, got: $(tr '\n' '|' <<<"$home_quiet_stderr")"
+fi
+
+# QUIET_OVERRIDE=1 must NOT suppress warn: severity. The PR contract
+# states 'warn: and error: always emit'. Only the error: passthrough was
+# previously verified — add a malformed-row source under QUIET_OVERRIDE=1
+# and assert the warn: line still surfaces. A future refactor widening
+# the QUIET guard to also wrap warn() would land green without this.
+warn_quiet_proj="$(mktemp -d -t dfd-warnq.XXXXXX)"
+mkdir -p "$warn_quiet_proj/.claude/dogfood"
+{
+    echo 'BAD_ROW_NOT_JSON'
+    echo '{"ts":"2026-04-25T00:00:00Z","type":"note","category":"pain","text":"valid"}'
+} > "$warn_quiet_proj/.claude/dogfood/log.jsonl"
+warn_quiet_stderr=$(CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1 "$aggregator" --all \
+    --scope local --project-root "$warn_quiet_proj" --home "$tmphome" 2>&1 >/dev/null)
+if printf '%s' "$warn_quiet_stderr" | grep -F -q -- 'warn: skipping malformed row'; then
+    pass "QUIET_OVERRIDE=1 does NOT suppress warn: severity (warn still emitted)"
+else
+    faile "QUIET_OVERRIDE warn scope" "expected 'warn: skipping malformed row', stderr=$(tr '\n' '|' <<<"$warn_quiet_stderr")"
+fi
+rm -rf "$warn_quiet_proj"
 
 # ----------------------------------------------------------------------------
 # Summary

--- a/docs/skills/dogfood-digest.ko.md
+++ b/docs/skills/dogfood-digest.ko.md
@@ -1,4 +1,4 @@
-# `/dogfood-digest` *(v1.2.0)*
+# `/dogfood-digest` *(v1.3.0)*
 
 > 누적된 `/crucible:dogfood` JSONL 을 read-only Markdown 제안 리포트 1건으로 정리 — 고정 3섹션(Threshold Calibration · Protocol Improvements · Promotion Candidates) + 인용된 모든 이벤트의 원본 위치 back-reference.
 
@@ -33,6 +33,41 @@
 - **`_source_path` + `_line` 메모리 주입.** back-reference 는 타협 불가 — 근거 없는 제안은 민담입니다. 집계 단계에서 jq 한 줄로 주입되고 원본 파일은 mutate 하지 않습니다.
 - **관측수 하한(`--threshold-n 3`).** 샘플 2개로 qa-judge 밴드를 튜닝하는 것은 튜닝하지 않는 것보다 나쁩니다 — 노이즈를 공식화하니까요. 주간 실행에서 실제 신호를 surfacing 할 만큼 낮고 n=1 우연을 억제할 만큼 높습니다. 조용한 로그를 위해 override 가능하도록 플래그로 노출.
 - **`/crucible:*` 그룹 토큰 + `general` 버킷.** 더 풍부한 NLP 그룹핑은 drift 합니다 — 토픽 벡터는 불만이 어느 스킬의 것인지 알려주지 않습니다. 슬래시 커맨드 토큰은 여전히 *이름이 붙은 스킬의 SKILL.md*라는 actionable 지점과 1:1 매핑되는 가장 거친 키입니다. 나머지는 `general` 로 흘러 silently drop 되지 않습니다.
+
+## 표준에러 & 종료 코드 (Stderr & Exit Codes) *(v1.3.0 추가, issues #16/#17/#18)*
+
+파이프라인의 두 절반 (`scripts/dogfood-digest.sh` 집계기, `scripts/dogfood-digest-render.sh` 렌더러) 모두 stderr 를 프로그램 호출자를 위한 구조화된 채널로 다룹니다. 세 가지 보장:
+
+**Severity prefix.** 스크립트 자체의 `err`/`warn`/`info` 헬퍼를 통해 방출되는 모든 stderr 라인은 `<script>: <severity>: <msg>` 형태이며 severity ∈ `{info, warn, error}`. 집계기는 `dogfood-digest:`, 렌더러는 `render:` 접두사. 통합 grep:
+
+```bash
+grep -E '^(dogfood-digest|render): (info|warn|error):'
+```
+
+복구 힌트는 `error:` 라인 뒤에 별도 `info: hint:` 라인으로 따라올 수 있습니다 (예: `--since` UTC 보정 힌트). `error:` 만 grep 하는 에이전트는 결함만 보고 권고는 놓치므로, 권고는 `info: hint:` 로 grep.
+
+**3-way 종료 코드 분리** (이전의 arg-vs-success 2-way 대체):
+
+| 코드 | 의미 | 호출자 액션 |
+|---|---|---|
+| 0 | 성공 (빈 입력 / no-signal 포함) | — |
+| 1 | 런타임 데이터-파이프라인 실패 (jq sort, mv swap, tail) | 데이터 형상 문제; 입력 점검 |
+| 2 | 인자 오류 (unknown flag, mutex, 잘못된 값, 중복) | 플래그 수정 후 재시도 |
+| 3 | 시스템 / 환경 실패 (디스크 가득, 도구 누락 시 mktemp) | 에스컬레이트, 동일 인자로 **재시도 금지** |
+
+`mktemp` 실패만 2 → 3 으로 이동. 다른 모든 인자 검증 사이트는 exit 2 유지.
+
+**Per-source warn rate-limit.** 수천 건의 malformed row 가 든 병적 JSONL 로그는 row 마다 `warn:` 한 줄을 방출해 에이전트 컨텍스트 예산을 폭파시키고 stderr 를 무시하도록 학습시켰습니다. 이제 source 당 verbatim `warn:` 5 줄로 cap; 그 이상은 단일 요약 라인으로 폴딩:
+
+```
+dogfood-digest: warn: N more malformed rows skipped in <path> (cap=5)
+```
+
+cap 값은 동적으로 보간(`(cap=5)`)되어 라인을 읽는 에이전트가 `--help` 없이도 cap 을 복원할 수 있습니다. Counter 는 source 마다 리셋되어 한 파일이 다른 파일의 warn 예산을 가리지 않습니다.
+
+**`CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1`.** 매 호출마다 `CRUCIBLE_DOGFOOD_ROOT` / `CRUCIBLE_DOGFOOD_HOME` 을 정상적으로 설정하는 CI 워크플로는 침묵을 opt-in 해서 env-override `info:` 라인이 stderr 를 흐리지 않도록 할 수 있습니다. **엄격한 리터럴 `"1"`** — `true`, `yes`, ` 1`(앞쪽 공백) 등 다른 값은 활성화되지 **않습니다**. **오직 `info:` env-override 라인만 억제**; `warn:` 와 `error:` 는 항상 방출됩니다 (opt-in 은 선택적 노이즈 감소이지 결함 마스킹이 아닙니다).
+
+**호환성 주의사항.** stderr 를 정확한 라인 일치로 파싱하거나 exit 2 를 "모든 실패"로 분기하던 wrapper 는 업데이트가 필요합니다. 부분 문자열 매칭(파일 경로, 오류 키워드)이나 exit-0 vs non-zero 매처는 영향 없음.
 
 ## 임계값 (Thresholds)
 

--- a/docs/skills/dogfood-digest.md
+++ b/docs/skills/dogfood-digest.md
@@ -1,4 +1,4 @@
-# `/dogfood-digest` *(v1.2.0)*
+# `/dogfood-digest` *(v1.3.0)*
 
 > Turn accumulated `/crucible:dogfood` JSONL into a single read-only Markdown proposal report — three fixed sections (Threshold Calibration · Protocol Improvements · Promotion Candidates) with back-references to every source event cited.
 
@@ -33,6 +33,41 @@ Recursion guard: any `skill_call` event whose `skill` contains `crucible:dogfood
 - **`_source_path` + `_line` injected in-memory.** The back-reference is the non-negotiable piece: a suggestion without provenance is folklore. Injecting the fields at aggregation time costs one jq pipeline and never touches the source file.
 - **Observation-count floor (`--threshold-n 3`).** Tuning a qa-judge band off two samples is worse than tuning off none — it codifies noise. The floor is low enough to surface real signal in a weekly run and high enough to suppress n=1 flukes. It is explicitly exposed so power users can override for quiet logs.
 - **`/crucible:*` grouping token + `general` bucket.** A richer NLP grouping was tried and drifted: topic vectors don't tell the user which *skill* a complaint belongs to. The slash-command token is the coarsest key that still maps one-to-one to an actionable locus (the named skill's SKILL.md). Everything else falls into `general` so it isn't silently dropped.
+
+## Stderr & Exit Codes *(added in v1.3.0, issues #16/#17/#18)*
+
+Both pipeline halves (`scripts/dogfood-digest.sh` aggregator and `scripts/dogfood-digest-render.sh` renderer) treat stderr as a structured channel for programmatic consumers. Three guarantees:
+
+**Severity prefix.** Every stderr line emitted via the script's own `err`/`warn`/`info` helpers carries the shape `<script>: <severity>: <msg>` where severity ∈ `{info, warn, error}`. The aggregator prefixes with `dogfood-digest:`; the renderer with `render:`. Unified pipeline grep:
+
+```bash
+grep -E '^(dogfood-digest|render): (info|warn|error):'
+```
+
+Recovery hints sometimes follow an `error:` line as a separate `info: hint:` line (e.g. the `--since` UTC fix-it hint). Agents that grep only `error:` see the fault but not the suggested fix; grep `info: hint:` for guidance.
+
+**3-way exit code split** (replaces the prior 2-way arg-vs-success):
+
+| Code | Meaning | Caller action |
+|---|---|---|
+| 0 | success (including empty / no-signal input) | — |
+| 1 | runtime data-pipeline failure (jq sort, mv swap, tail) | data-shape issue; inspect input |
+| 2 | argument error (unknown flag, mutex, bad value, duplicate) | fix the flag and retry |
+| 3 | system / environment failure (mktemp on full disk, missing tools) | escalate, do **not** retry the same args |
+
+Only `mktemp` failures move from 2 → 3. Every other arg-validation site stays at exit 2.
+
+**Per-source warn rate-limit.** A pathological JSONL log with thousands of malformed rows used to emit one `warn:` line per bad row, blowing agent context budgets and training agents to ignore stderr entirely. Now capped at 5 verbatim `warn:` lines per source; anything beyond emits a single summary line:
+
+```
+dogfood-digest: warn: N more malformed rows skipped in <path> (cap=5)
+```
+
+The cap value is interpolated dynamically (`(cap=5)`), so an agent reading the line can recover the cap without consulting `--help`. Counters reset between sources so one bad file doesn't shadow the warn budget for others.
+
+**`CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1`.** CI workflows that legitimately set `CRUCIBLE_DOGFOOD_ROOT` / `CRUCIBLE_DOGFOOD_HOME` on every invocation can opt into silence so the env-override `info:` line doesn't flood stderr. **Strict literal `"1"`** — `true`, `yes`, ` 1` (leading space), or any other value does NOT enable. Suppresses **only** the `info:` env-override line; `warn:` and `error:` always emit (the opt-in is chosen-noise reduction, never failure masking).
+
+**Backward-compat caveat.** Wrappers that parse stderr by exact-line content or branch on exit 2 expecting "any failure" need to update. Substring matching (file paths, error keywords) is unaffected; exit-0 vs non-zero matchers are unaffected.
 
 ## Thresholds
 

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -30,14 +30,29 @@
 # `--threshold-n 1 --threshold-n 99` would suppress signal a caller intended
 # to surface.
 #
-# Exit codes:
+# Stderr: every line carries `render: <severity>: <message>` where severity ∈
+# {info, warn, error} (issue #16). Symmetric with the aggregator so a wrapper
+# can keyword-match severity across both halves of the pipeline uniformly.
+#
+# Exit codes (issue #16 — arg vs system split):
 #   0  success (including empty or no-signal input)
-#   1  runtime failure (jq pipeline error, etc.)
-#   2  argument error (unknown flag, duplicate flag, bad value, mktemp failure)
+#   1  runtime data-pipeline failure (jq ingestion error)
+#   2  argument error (unknown flag, duplicate flag, bad value)
+#   3  system / environment failure (mktemp full disk, missing tools)
 #
 # Runtime: bash + jq. No Python / Node.
 
 set -uo pipefail
+
+# Severity-tagged stderr emitters (issue #16). Mirrors the aggregator's
+# helpers so both halves of the pipeline emit `<script>: <severity>: <msg>`
+# uniformly.
+# shellcheck disable=SC2059  # fmt is an internal format string, not user input
+err() { local fmt="$1"; shift; printf "render: error: ${fmt}\\n" "$@" >&2; }
+# shellcheck disable=SC2059
+warn() { local fmt="$1"; shift; printf "render: warn: ${fmt}\\n" "$@" >&2; }
+# shellcheck disable=SC2059
+info() { local fmt="$1"; shift; printf "render: info: ${fmt}\\n" "$@" >&2; }
 
 print_help() {
     cat <<'USAGE'
@@ -60,10 +75,15 @@ Constraints:
   --threshold-n is a positive integer in [1, 1000000]; out-of-range → exit 2.
   Each named flag may appear at most once (duplicate → exit 2).
 
-Exit codes:
-  0 — success (including empty or no-signal input)
-  1 — runtime failure (jq pipeline error, etc.)
-  2 — argument error
+Stderr severity tagging:
+  Every stderr line is prefixed `render: <severity>: <msg>` where
+  severity ∈ {info, warn, error} (matches the aggregator's contract).
+
+Exit codes (arg / runtime / system split, see issue #16):
+  0  success (including empty or no-signal input)
+  1  runtime data-pipeline failure (jq ingestion error)
+  2  argument error
+  3  system/environment failure (mktemp full disk, missing tools)
 USAGE
 }
 
@@ -79,7 +99,7 @@ saw_scope=0
 saw_threshold_n=0
 
 reject_duplicate() {
-    printf 'render: %s passed more than once — pass it at most once\n' "$1" >&2
+    err '%s passed more than once — pass it at most once' "$1"
     exit 2
 }
 
@@ -92,26 +112,26 @@ while [[ $# -gt 0 ]]; do
             if [[ "$saw_window" -eq 1 ]]; then reject_duplicate --window; fi
             saw_window=1
             window_label="${2:-}"
-            shift 2 || { printf 'render: --window requires a value\n' >&2; exit 2; }
+            shift 2 || { err '--window requires a value'; exit 2; }
             ;;
         --scope)
             if [[ "$saw_scope" -eq 1 ]]; then reject_duplicate --scope; fi
             saw_scope=1
             scope_label="${2:-}"
-            shift 2 || { printf 'render: --scope requires a value\n' >&2; exit 2; }
+            shift 2 || { err '--scope requires a value'; exit 2; }
             ;;
         --threshold-n)
             if [[ "$saw_threshold_n" -eq 1 ]]; then reject_duplicate --threshold-n; fi
             saw_threshold_n=1
             threshold_n="${2:-}"
-            shift 2 || { printf 'render: --threshold-n requires a value\n' >&2; exit 2; }
+            shift 2 || { err '--threshold-n requires a value'; exit 2; }
             ;;
         -h|--help)
             print_help
             exit 0
             ;;
         *)
-            printf 'render: unknown argument: %s\n' "$1" >&2
+            err 'unknown argument: %s' "$1"
             print_help >&2
             exit 2
             ;;
@@ -130,7 +150,7 @@ done
 find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'dogfood-digest-in.*' -mmin +60 -delete 2>/dev/null || true
 
 if [[ -z "$window_label" ]]; then
-    printf 'render: --window is required\n' >&2
+    err '--window is required'
     exit 2
 fi
 
@@ -139,13 +159,13 @@ fi
 case "$scope_label" in
     local|global|both) ;;
     *)
-        printf 'render: --scope must be local, global, or both (got: %s)\n' "$scope_label" >&2
+        err '--scope must be local, global, or both (got: %s)' "$scope_label"
         exit 2
         ;;
 esac
 
 if ! [[ "$threshold_n" =~ ^[0-9]+$ ]]; then
-    printf 'render: --threshold-n expects a positive integer (got: %s)\n' "$threshold_n" >&2
+    err '--threshold-n expects a positive integer (got: %s)' "$threshold_n"
     exit 2
 fi
 # Length-bound BEFORE arithmetic, mirroring the aggregator's --last guard
@@ -157,18 +177,20 @@ fi
 # close, just on a sibling flag. Cap is 1_000_000 (7 digits) to match the
 # aggregator's --last contract; both are observation-count knobs.
 if [[ ${#threshold_n} -gt 7 ]]; then
-    printf 'render: --threshold-n must be a positive integer <= 1000000 (got: %s)\n' "$threshold_n" >&2
+    err '--threshold-n must be a positive integer <= 1000000 (got: %s)' "$threshold_n"
     exit 2
 fi
 threshold_n=$((10#$threshold_n))
 if [[ "$threshold_n" -le 0 ]] || [[ "$threshold_n" -gt 1000000 ]]; then
-    printf 'render: --threshold-n must be a positive integer <= 1000000 (got: %s)\n' "$threshold_n" >&2
+    err '--threshold-n must be a positive integer <= 1000000 (got: %s)' "$threshold_n"
     exit 2
 fi
 
+# mktemp failure is a system / environment issue (issue #16) — exit 3 lets
+# retry-loop wrappers distinguish "fix the flag" (2) from "escalate" (3).
 tmp_in="$(mktemp -t dogfood-digest-in.XXXXXX)" || {
-    printf 'render: mktemp failed\n' >&2
-    exit 2
+    err 'mktemp failed (system error — escalate, do not retry)'
+    exit 3
 }
 # EXIT covers normal exit; INT/TERM/HUP cover SIGINT/SIGTERM/SIGHUP so the
 # tempfile does not leak when the renderer is interrupted mid-pipeline.
@@ -189,7 +211,7 @@ trap 'rm -f "$tmp_in"' EXIT INT TERM HUP
 # count would degrade to "no signal in window" with exit 0 — a "success
 # but wrong answer" failure mode. Surface jq errors instead of swallowing.
 if ! jq -c 'select(if .type == "skill_call" then (if (.skill | type) == "string" then ((.skill | ascii_downcase) | test("^/?crucible:dogfood-digest$"; "i") | not) else true end) else true end)' > "$tmp_in"; then
-    printf 'render: ingestion jq failed (malformed JSONL on stdin?)\n' >&2
+    err 'ingestion jq failed (malformed JSONL on stdin?)'
     exit 1
 fi
 

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -76,14 +76,18 @@ Constraints:
   Each named flag may appear at most once (duplicate → exit 2).
 
 Stderr severity tagging:
-  Every stderr line is prefixed `render: <severity>: <msg>` where
-  severity ∈ {info, warn, error} (matches the aggregator's contract).
+  Every stderr line below the targeted error/warn/info helpers is prefixed
+  `render: <severity>: <msg>` where severity ∈ {info, warn, error}
+  (matches the aggregator's contract). Aggregator prefix is
+  `dogfood-digest: <severity>:` — for unified pipeline grep:
+      grep -E '^(dogfood-digest|render): (info|warn|error):'
 
 Exit codes (arg / runtime / system split, see issue #16):
   0  success (including empty or no-signal input)
   1  runtime data-pipeline failure (jq ingestion error)
-  2  argument error
-  3  system/environment failure (mktemp full disk, missing tools)
+  2  argument error — fix the flag and retry
+  3  system/environment failure (mktemp full disk, missing tools) —
+     escalate, do not retry the same args
 USAGE
 }
 
@@ -132,7 +136,12 @@ while [[ $# -gt 0 ]]; do
             ;;
         *)
             err 'unknown argument: %s' "$1"
-            print_help >&2
+            # Drop the unprefixed `print_help >&2` dump (~30 lines) — it
+            # bypassed the err/warn/info helpers and broke the
+            # `^render:` anchored-grep contract that issue #16 enabled.
+            # Mirror the aggregator: one actionable info line pointing
+            # at --help.
+            info 'for full usage: bash scripts/dogfood-digest-render.sh --help'
             exit 2
             ;;
     esac

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -102,16 +102,27 @@ printed to stderr so the override is never silent.
 Exit codes (arg / runtime / system split, see issue #16):
   0  success
   1  runtime data-pipeline failure (jq/mv/tail)
-  2  argument error
-  3  system/environment failure (mktemp full disk, missing tools)
+  2  argument error — fix the flag and retry
+  3  system/environment failure (mktemp full disk, missing tools) —
+     escalate, do not retry the same args
 
 Stderr severity tagging:
-  Every stderr line is prefixed `dogfood-digest: <severity>: <msg>` where
-  severity ∈ {info, warn, error}. Per-source malformed-row warnings cap
-  at 5 with a summary line for any extras.
+  Every stderr line below the targeted error/warn/info helpers is prefixed
+  `dogfood-digest: <severity>: <msg>` where severity ∈ {info, warn, error}.
+  Per-source malformed-row warnings cap at 5 with a summary line for any
+  extras. Summary line format:
+      dogfood-digest: warn: N more malformed rows skipped in <path> (cap=5)
+  Recovery hints sometimes follow an `error:` line as a separate `info:`
+  line (e.g. the --since UTC fix-it hint). Agents that grep only `error:`
+  see the fault but not the suggested fix; grep `info: hint:` for guidance.
+  Renderer prefix is `render: <severity>:` — for unified pipeline grep:
+      grep -E '^(dogfood-digest|render): (info|warn|error):'
 
 Env var:
-  CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1  suppress env-override info line.
+  CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1  suppress the env-override info line
+                                     (info: severity only; warn:/error:
+                                     always emit). Strict literal "1" —
+                                     "true"/"yes"/" 1" do NOT enable.
 
 For render-time flags (--window, --threshold-n), see:
   bash scripts/dogfood-digest-render.sh --help
@@ -213,7 +224,14 @@ while [[ $# -gt 0 ]]; do
                     info 'for full usage: bash scripts/dogfood-digest.sh --help'
                     ;;
                 *)
-                    print_help >&2
+                    # Drop the unprefixed `print_help >&2` dump (~37 lines)
+                    # — it bypassed the err/warn/info helpers and broke the
+                    # `^dogfood-digest:` anchored-grep contract that issue
+                    # #16 enabled. Mirror the misroute pattern: one
+                    # actionable info line pointing at --help. Agents that
+                    # need the full usage grep `--help`; humans get the
+                    # same one-line pointer.
+                    info 'for full usage: bash scripts/dogfood-digest.sh --help'
                     ;;
             esac
             exit 2
@@ -336,7 +354,8 @@ if [[ "$window_mode" == "since" ]]; then
         # user can map the error to their input regardless of which
         # malformed shape they passed.
         err '--since ISO8601 must be YYYY-MM-DDTHH:MM:SSZ (UTC); got: %s' "$window_since"
-        info 'rewrite with Z (UTC) suffix, or pass YYYY-MM-DD'
+        info 'hint: rewrite with Z (UTC) suffix, or pass YYYY-MM-DD'
+        info 'hint: if this value is generated upstream, the source pipeline must emit UTC — retrying with the same generator will loop'
         exit 2
     else
         err '--since must be YYYY-MM-DD, YYYY-MM-DDTHH:MM:SSZ, or Nd (got: %s)' "$window_since"
@@ -443,8 +462,15 @@ for src in "${sources[@]}"; do
     # severity so it groups naturally with the verbatim lines under any
     # severity-based filter.
     if [[ "$src_warn_skipped" -gt 0 ]]; then
-        warn '%s more malformed rows skipped in %s (cap=%s)' \
-            "$src_warn_skipped" "$src" "$WARN_CAP"
+        # Pluralize-aware noun so the count==1 boundary doesn't read as
+        # "1 more malformed rows skipped" (singular subject + plural noun).
+        if [[ "$src_warn_skipped" -eq 1 ]]; then
+            row_word="row"
+        else
+            row_word="rows"
+        fi
+        warn '%s more malformed %s skipped in %s (cap=%s)' \
+            "$src_warn_skipped" "$row_word" "$src" "$WARN_CAP"
     fi
 done
 

--- a/scripts/dogfood-digest.sh
+++ b/scripts/dogfood-digest.sh
@@ -37,19 +37,43 @@
 #   CRUCIBLE_DOGFOOD_ROOT  overrides --project-root for local log resolution
 #   CRUCIBLE_DOGFOOD_HOME  overrides --home for global mirror resolution
 # When either env var is applied, a one-line info message is written to stderr
-# so overrides are never silent.
+# so overrides are never silent. Set CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1 to
+# suppress that one info line in CI runs that legitimately set the env vars
+# on every invocation (issue #18).
 #
 # Output: JSONL on stdout. Empty input → no lines, exit 0.
 #
-# Exit codes:
+# Stderr: every line carries `dogfood-digest: <severity>: <message>` where
+# severity ∈ {info, warn, error} (issue #16). This lets agents keyword-match
+# severity without parsing free-form prose. Per-row malformed-line warnings
+# are rate-limited: first 5 per source emit verbatim, the rest are folded
+# into a one-line summary at end-of-source (issue #17).
+#
+# Exit codes (issue #16 — arg vs system split):
 #   0  success (including empty input / zero sources)
-#   1  runtime failure (jq/date/mv/tail pipeline error)
+#   1  runtime data-pipeline failure (jq sort, mv, tail) — input data shape
+#      violated an invariant
 #   2  argument error (unknown flag, duplicate flag, mutex violation,
-#                       bad value, mktemp failure)
+#                       bad value) — recoverable, retry with fixed args
+#   3  system / environment failure (mktemp on full disk, missing tools) —
+#      escalate, do NOT retry the same args
 #
 # Runtime: bash (>=4) + jq (>=1.6) + date. No Python / Node.
 
 set -uo pipefail
+
+# Severity-tagged stderr emitters (issue #16). Centralising the prefix
+# means future call sites stay consistent without re-typing the severity
+# token. Each takes a printf format string + args; appends \n. Usage:
+#   err  '--last expects a positive integer (got: %s)' "$x"
+#   warn 'skipping malformed row %s:%s' "$src" "$line_no"
+#   info 'CRUCIBLE_DOGFOOD_ROOT=%s overrides --project-root=%s' "$a" "$b"
+# shellcheck disable=SC2059  # fmt is an internal format string, not user input
+err() { local fmt="$1"; shift; printf "dogfood-digest: error: ${fmt}\\n" "$@" >&2; }
+# shellcheck disable=SC2059
+warn() { local fmt="$1"; shift; printf "dogfood-digest: warn: ${fmt}\\n" "$@" >&2; }
+# shellcheck disable=SC2059
+info() { local fmt="$1"; shift; printf "dogfood-digest: info: ${fmt}\\n" "$@" >&2; }
 
 print_help() {
     cat <<'USAGE'
@@ -75,10 +99,19 @@ Test-only env vars (take precedence over the matching flags when set):
 When either env var changes the resolved path, a one-line info message is
 printed to stderr so the override is never silent.
 
-Exit codes:
+Exit codes (arg / runtime / system split, see issue #16):
   0  success
-  1  runtime failure
+  1  runtime data-pipeline failure (jq/mv/tail)
   2  argument error
+  3  system/environment failure (mktemp full disk, missing tools)
+
+Stderr severity tagging:
+  Every stderr line is prefixed `dogfood-digest: <severity>: <msg>` where
+  severity ∈ {info, warn, error}. Per-source malformed-row warnings cap
+  at 5 with a summary line for any extras.
+
+Env var:
+  CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1  suppress env-override info line.
 
 For render-time flags (--window, --threshold-n), see:
   bash scripts/dogfood-digest-render.sh --help
@@ -111,7 +144,7 @@ saw_home=0
 # message. Centralised so adding a new dedup'd flag stays one line in the
 # case branch instead of duplicating the printf.
 reject_duplicate() {
-    printf 'dogfood-digest: %s passed more than once — pass it at most once\n' "$1" >&2
+    err '%s passed more than once — pass it at most once' "$1"
     exit 2
 }
 
@@ -122,7 +155,7 @@ while [[ $# -gt 0 ]]; do
             saw_last=1
             window_mode="last"
             window_last="${2:-}"
-            shift 2 || { printf 'dogfood-digest: --last requires a value\n' >&2; exit 2; }
+            shift 2 || { err '--last requires a value'; exit 2; }
             ;;
         --since)
             # `if [[ ]]; then …; fi` (not `[[ ]] && …`) so a future `set -e`
@@ -132,7 +165,7 @@ while [[ $# -gt 0 ]]; do
             saw_since=1
             window_mode="since"
             window_since="${2:-}"
-            shift 2 || { printf 'dogfood-digest: --since requires a value\n' >&2; exit 2; }
+            shift 2 || { err '--since requires a value'; exit 2; }
             ;;
         --all)
             if [[ "$saw_all" -eq 1 ]]; then reject_duplicate --all; fi
@@ -144,36 +177,40 @@ while [[ $# -gt 0 ]]; do
             if [[ "$saw_scope" -eq 1 ]]; then reject_duplicate --scope; fi
             saw_scope=1
             scope="${2:-}"
-            shift 2 || { printf 'dogfood-digest: --scope requires a value\n' >&2; exit 2; }
+            shift 2 || { err '--scope requires a value'; exit 2; }
             ;;
         --project-root)
             if [[ "$saw_project_root" -eq 1 ]]; then reject_duplicate --project-root; fi
             saw_project_root=1
             project_root="${2:-}"
-            shift 2 || { printf 'dogfood-digest: --project-root requires a value\n' >&2; exit 2; }
+            shift 2 || { err '--project-root requires a value'; exit 2; }
             ;;
         --home)
             if [[ "$saw_home" -eq 1 ]]; then reject_duplicate --home; fi
             saw_home=1
             home_dir="${2:-}"
-            shift 2 || { printf 'dogfood-digest: --home requires a value\n' >&2; exit 2; }
+            shift 2 || { err '--home requires a value'; exit 2; }
             ;;
         -h|--help)
             print_help
             exit 0
             ;;
         *)
-            printf 'dogfood-digest: unknown argument: %s\n' "$1" >&2
+            err 'unknown argument: %s' "$1"
             # Recognized misroute: render-time flag passed to the aggregator.
             # Skip the ~40-line print_help dump and emit just the targeted
             # hint plus a one-line pointer to --help. The wall of help text
             # would scroll the actionable hint off screen on terminals with
             # short scrollback (codex pr#21 review). For unrecognized flags
-            # the full help is still useful as a discovery aid.
+            # the full help is still useful as a discovery aid. The hint
+            # line stays `info:` severity because the ERROR is "unknown
+            # argument" (already emitted above) and the hint is recovery
+            # context — separating them lets agents grep `error:` for the
+            # fault line and `info:` for actionable guidance.
             case "$1" in
                 --window|--threshold-n)
-                    printf 'dogfood-digest: hint — %s is a render-time flag; pass it to scripts/dogfood-digest-render.sh instead.\n' "$1" >&2
-                    printf 'dogfood-digest: for full usage: bash scripts/dogfood-digest.sh --help\n' >&2
+                    info 'hint: %s is a render-time flag; pass it to scripts/dogfood-digest-render.sh instead.' "$1"
+                    info 'for full usage: bash scripts/dogfood-digest.sh --help'
                     ;;
                 *)
                     print_help >&2
@@ -200,7 +237,7 @@ find "${TMPDIR:-/tmp}" -maxdepth 1 -name 'dogfood-digest-raw.*' -mmin +60 -delet
 # Mutex: --last and --since cannot be combined. --all takes precedence and
 # collapses the conflict (documented as "--all overrides both").
 if [[ "$saw_all" -eq 0 && "$saw_last" -eq 1 && "$saw_since" -eq 1 ]]; then
-    printf 'dogfood-digest: --last and --since are mutually exclusive — pass one or use --all\n' >&2
+    err '--last and --since are mutually exclusive — pass one or use --all'
     exit 2
 fi
 
@@ -214,14 +251,14 @@ fi
 case "$scope" in
     local|global|both) ;;
     *)
-        printf 'dogfood-digest: --scope must be local, global, or both (got: %s)\n' "$scope" >&2
+        err '--scope must be local, global, or both (got: %s)' "$scope"
         exit 2
         ;;
 esac
 
 if [[ "$window_mode" == "last" ]]; then
     if ! [[ "$window_last" =~ ^[0-9]+$ ]]; then
-        printf 'dogfood-digest: --last expects a positive integer (got: %s)\n' "$window_last" >&2
+        err '--last expects a positive integer (got: %s)' "$window_last"
         exit 2
     fi
     # Length-bound the input BEFORE any bash arithmetic. The cap is 1_000_000
@@ -236,7 +273,7 @@ if [[ "$window_mode" == "last" ]]; then
     # would force stderr scrapers to handle both; ASCII <= avoids non-UTF-8
     # capture-pipeline corruption (PR #24 P3 #5 review).
     if [[ ${#window_last} -gt 7 ]]; then
-        printf 'dogfood-digest: --last must be a positive integer <= 1000000 (got: %s)\n' "$window_last" >&2
+        err '--last must be a positive integer <= 1000000 (got: %s)' "$window_last"
         exit 2
     fi
     # Force base-10 so values like "010" are not interpreted as octal in
@@ -245,7 +282,7 @@ if [[ "$window_mode" == "last" ]]; then
     # diverging from the value tail(1) actually receives downstream.
     window_last=$((10#$window_last))
     if [[ "$window_last" -le 0 ]] || [[ "$window_last" -gt 1000000 ]]; then
-        printf 'dogfood-digest: --last must be a positive integer <= 1000000 (got: %s)\n' "$window_last" >&2
+        err '--last must be a positive integer <= 1000000 (got: %s)' "$window_last"
         exit 2
     fi
 fi
@@ -255,7 +292,7 @@ fi
 cutoff_iso=""
 if [[ "$window_mode" == "since" ]]; then
     if [[ -z "$window_since" ]]; then
-        printf 'dogfood-digest: --since requires a DATE or Nd duration\n' >&2
+        err '--since requires a DATE or Nd duration'
         exit 2
     fi
     if [[ "$window_since" =~ ^([0-9]+)d$ ]]; then
@@ -266,12 +303,12 @@ if [[ "$window_mode" == "since" ]]; then
         # successful "--since-99999d" run while returning the entire log.
         if date -v-1d +%Y-%m-%d >/dev/null 2>&1; then
             if ! cutoff_iso="$(date -u -v-"${days}"d +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || [[ -z "$cutoff_iso" ]]; then
-                printf 'dogfood-digest: --since %sd is out of range for date(1)\n' "$days" >&2
+                err '--since %sd is out of range for date(1)' "$days"
                 exit 2
             fi
         else
             if ! cutoff_iso="$(date -u -d "${days} days ago" +%Y-%m-%dT%H:%M:%SZ 2>/dev/null)" || [[ -z "$cutoff_iso" ]]; then
-                printf 'dogfood-digest: --since %sd is out of range for date(1)\n' "$days" >&2
+                err '--since %sd is out of range for date(1)' "$days"
                 exit 2
             fi
         fi
@@ -298,11 +335,11 @@ if [[ "$window_mode" == "since" ]]; then
         # expected shape (instead of imputing "non-UTC datetime") so the
         # user can map the error to their input regardless of which
         # malformed shape they passed.
-        printf 'dogfood-digest: --since ISO8601 must be YYYY-MM-DDTHH:MM:SSZ (UTC); got: %s\n' "$window_since" >&2
-        printf '  → rewrite with Z (UTC) suffix, or pass YYYY-MM-DD\n' >&2
+        err '--since ISO8601 must be YYYY-MM-DDTHH:MM:SSZ (UTC); got: %s' "$window_since"
+        info 'rewrite with Z (UTC) suffix, or pass YYYY-MM-DD'
         exit 2
     else
-        printf 'dogfood-digest: --since must be YYYY-MM-DD, YYYY-MM-DDTHH:MM:SSZ, or Nd (got: %s)\n' "$window_since" >&2
+        err '--since must be YYYY-MM-DD, YYYY-MM-DDTHH:MM:SSZ, or Nd (got: %s)' "$window_since"
         exit 2
     fi
 fi
@@ -312,14 +349,20 @@ fi
 # Root override for dogfood storage (CI/test hook). Falls back to project_root
 # for locals, and $home_dir/.claude/dogfood/crucible for globals. When an env
 # var actually changes the resolved path, emit a one-line stderr info so the
-# override is never silent.
-if [[ -n "${CRUCIBLE_DOGFOOD_ROOT:-}" && "${CRUCIBLE_DOGFOOD_ROOT}" != "$project_root" ]]; then
-    printf 'dogfood-digest: info: CRUCIBLE_DOGFOOD_ROOT=%s overrides --project-root=%s\n' \
-        "$CRUCIBLE_DOGFOOD_ROOT" "$project_root" >&2
-fi
-if [[ -n "${CRUCIBLE_DOGFOOD_HOME:-}" && "${CRUCIBLE_DOGFOOD_HOME}" != "$home_dir" ]]; then
-    printf 'dogfood-digest: info: CRUCIBLE_DOGFOOD_HOME=%s overrides --home=%s\n' \
-        "$CRUCIBLE_DOGFOOD_HOME" "$home_dir" >&2
+# override is never silent — UNLESS the caller has explicitly opted into
+# silence via CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1 (issue #18). The opt-in is
+# for CI workflows that legitimately set the env vars on every invocation
+# and don't want the info-line noise to push agents toward "ignore stderr
+# entirely" (which would mask the warn/error lines that DO matter).
+if [[ "${CRUCIBLE_DOGFOOD_QUIET_OVERRIDE:-0}" != "1" ]]; then
+    if [[ -n "${CRUCIBLE_DOGFOOD_ROOT:-}" && "${CRUCIBLE_DOGFOOD_ROOT}" != "$project_root" ]]; then
+        info 'CRUCIBLE_DOGFOOD_ROOT=%s overrides --project-root=%s' \
+            "$CRUCIBLE_DOGFOOD_ROOT" "$project_root"
+    fi
+    if [[ -n "${CRUCIBLE_DOGFOOD_HOME:-}" && "${CRUCIBLE_DOGFOOD_HOME}" != "$home_dir" ]]; then
+        info 'CRUCIBLE_DOGFOOD_HOME=%s overrides --home=%s' \
+            "$CRUCIBLE_DOGFOOD_HOME" "$home_dir"
+    fi
 fi
 local_log="${CRUCIBLE_DOGFOOD_ROOT:-$project_root}/.claude/dogfood/log.jsonl"
 global_glob="${CRUCIBLE_DOGFOOD_HOME:-$home_dir}/.claude/dogfood/crucible"
@@ -350,9 +393,13 @@ fi
 # Emit augmented JSONL: each line gets _source_path + _line. Filter by cutoff
 # when --since was provided; --last is applied after sort.
 
+# mktemp failure is a system / environment issue (full /tmp, permission, missing
+# /tmp altogether) — not a bad-arg condition. Issue #16 separates exit codes:
+# arg=2 vs system=3. Exiting 3 here lets retry-loop wrappers distinguish
+# "fix the flag and rerun" (2) from "escalate, do not retry the same args" (3).
 tmp_raw="$(mktemp -t dogfood-digest-raw.XXXXXX)" || {
-    printf 'dogfood-digest: mktemp failed\n' >&2
-    exit 2
+    err 'mktemp failed (system error — escalate, do not retry)'
+    exit 3
 }
 # Clean up both the raw buffer and its transient .sorted sibling on exit.
 # EXIT alone misses the SIGINT/SIGTERM/SIGHUP path on some shells, so the
@@ -360,12 +407,23 @@ tmp_raw="$(mktemp -t dogfood-digest-raw.XXXXXX)" || {
 # left to the OS.
 trap 'rm -f "$tmp_raw" "${tmp_raw}.sorted"' EXIT INT TERM HUP
 
+# Per-source warn rate-limit cap (issue #17). The first WARN_CAP malformed
+# rows in a source emit a verbatim `warn:` line; everything beyond that gets
+# folded into a single end-of-source summary. Without the cap, a corrupted
+# JSONL with thousands of bad rows blew through downstream agent context
+# budgets and trained agents to ignore stderr entirely (masking the
+# warnings that DO matter). 5 is a soft anchor: enough to surface a
+# diversity of bad-row shapes for diagnosis, low enough to bound the
+# stderr cost from a pathological log.
+readonly WARN_CAP=5
 for src in "${sources[@]}"; do
     # Process line-by-line so a single malformed row does NOT drop every
     # valid row after it. jq aborts the whole invocation on the first parse
     # error, so we must isolate each line. _source_path/_line are injected
     # per-line using the source's 1-based line number.
     line_no=0
+    src_warn_emitted=0
+    src_warn_skipped=0
     while IFS= read -r raw_line || [[ -n "$raw_line" ]]; do
         line_no=$((line_no + 1))
         [[ -z "$raw_line" ]] && continue
@@ -373,15 +431,26 @@ for src in "${sources[@]}"; do
             | jq -c --arg path "$src" --argjson ln "$line_no" \
                 '. + {_source_path: $path, _line: $ln}' \
                 2>/dev/null >> "$tmp_raw"; then
-            printf 'dogfood-digest: warn: skipping malformed row %s:%s\n' \
-                "$src" "$line_no" >&2
+            if [[ "$src_warn_emitted" -lt "$WARN_CAP" ]]; then
+                warn 'skipping malformed row %s:%s' "$src" "$line_no"
+                src_warn_emitted=$((src_warn_emitted + 1))
+            else
+                src_warn_skipped=$((src_warn_skipped + 1))
+            fi
         fi
     done < "$src"
+    # End-of-source summary line if any rows were folded. Stays `warn:`
+    # severity so it groups naturally with the verbatim lines under any
+    # severity-based filter.
+    if [[ "$src_warn_skipped" -gt 0 ]]; then
+        warn '%s more malformed rows skipped in %s (cap=%s)' \
+            "$src_warn_skipped" "$src" "$WARN_CAP"
+    fi
 done
 
 # Sort by ts ascending. Events without ts sort to the front (unlikely in practice).
 if ! jq -sc 'sort_by(.ts // "") | .[]' "$tmp_raw" > "${tmp_raw}.sorted"; then
-    printf 'dogfood-digest: sort pipeline failed\n' >&2
+    err 'sort pipeline failed'
     exit 1
 fi
 # Without this guard, an mv failure (e.g. disk full between sort and rename)
@@ -389,7 +458,7 @@ fi
 # return the last N rows by file order, not by timestamp — silent semantic
 # drift instead of a visible failure.
 if ! mv "${tmp_raw}.sorted" "$tmp_raw"; then
-    printf 'dogfood-digest: failed to swap sorted buffer into place\n' >&2
+    err 'failed to swap sorted buffer into place'
     exit 1
 fi
 
@@ -410,7 +479,7 @@ case "$window_mode" in
         # "no signal in window". The parse-time cap above already rejects
         # extreme values; this is defense-in-depth (issue #14).
         if ! tail -n "$window_last" "$tmp_raw"; then
-            printf 'dogfood-digest: tail failed for --last %s\n' "$window_last" >&2
+            err 'tail failed for --last %s' "$window_last"
             exit 1
         fi
         ;;

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -20,6 +20,9 @@ input: |
     --home DIR         (CI/test only) $HOME 대신 사용할 글로벌 mirror 루트.
     env CRUCIBLE_DOGFOOD_ROOT  위 --project-root 보다 우선. 적용 시 stderr 에 info.
     env CRUCIBLE_DOGFOOD_HOME  위 --home 보다 우선. 적용 시 stderr 에 info.
+    env CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1  env-override info 라인 억제 (issue
+                       #18). CI 가 매 호출마다 위 두 env 를 set 하는 경우 stderr
+                       노이즈를 제거하기 위한 옵트인. error/warn 은 영향 없음.
   같은 플래그를 두 번 패스하면 exit 2 — wrapper 가 사용자 인자를 자기
   default 와 단순 concat 할 때 마지막 값이 조용히 이기는 footgun을 차단한다
   (issue #9).
@@ -46,11 +49,18 @@ output: |
   프론트매터(generated_at · window · scope · total_events · source_counts) + Markdown 본문 3섹션
   (Threshold Calibration · Protocol Improvements · Promotion Candidates).
 
-  Exit codes (aggregator + renderer 공통):
+  Stderr (issue #16): 모든 라인이 `<script>: <severity>: <msg>` 형식.
+    severity ∈ {info, warn, error}. 에이전트가 자유 텍스트 파싱 없이
+    severity 키워드만으로 분류 가능. 파일별 malformed-row warn 은 5건까지
+    verbatim emit 후 1줄 summary 로 fold (issue #17).
+
+  Exit codes (aggregator + renderer 공통, 3-way 분리 — issue #16):
     0  성공 (zero-source / zero-signal 포함)
-    1  런타임 실패 (jq/date/mv/tail pipeline 에러)
+    1  런타임 데이터 파이프라인 실패 (jq/mv/tail) — 입력 데이터 invariant 위반
     2  인자 오류 (unknown flag, duplicate flag, mutex 위반, 잘못된 값,
-                  --last 범위 위반, mktemp 실패)
+                  --last 범위 위반) — recoverable, 인자 고쳐 재시도
+    3  시스템/환경 실패 (mktemp full disk, missing tools) — escalate, 동일
+                  인자 재시도 금지
 validate_prompt: |
   /crucible:dogfood-digest 완료 시 자기검증 (Dogfood-Digest 4축):
   1. 산출 파일 경로가 `.claude/plans/YYYY-MM-DD-dogfood-digest-{window}.md` 규약을 만족하고 slug `[a-zA-Z0-9_-]` 화이트리스트 내인가?


### PR DESCRIPTION
## Summary

Closes #16, #17, #18 — the "stderr UX polish" bundle from PR #7's ce-review residual queue. Three related issues that all shape how the dogfood-digest pair surfaces stderr to programmatic consumers.

## Issue #16 — severity prefix + exit-code split

**Before**: free-form prose stderr; `error:` prefix missing on fatal lines; exit code 2 conflated four classes (unknown flag, mutex, bad value, mktemp).

**After**:
- Every stderr line: `<script>: <severity>: <msg>` where severity ∈ `{info, warn, error}`. Centralised in `err`/`warn`/`info` helpers; ~30 call sites converted.
- Exit codes split 3-way:

| Code | Meaning | Caller action |
|---|---|---|
| 0 | success | — |
| 1 | runtime data-pipeline failure (jq sort, mv, tail) | data-shape issue |
| 2 | argument error (recoverable) | fix flag, retry |
| 3 | system / environment (mktemp full disk) | escalate, do NOT retry |

Only `mktemp` moves from 2→3. Intentionally minimal: only the case where retry is actively wrong gets the new code.

## Issue #17 — per-row warn rate-limit

**Before**: every malformed row → one verbatim `warn:` line, no cap. A corrupted JSONL with thousands of bad rows blew agent context budgets.

**After**:
- Cap of 5 verbatim `warn:` lines per source.
- Beyond cap → one summary: `N more malformed rows skipped in <path> (cap=5)`.
- Per-source counters reset between sources so one bad file doesn't shadow the warn budget for others.
- Below-cap behavior unchanged.

## Issue #18 — `CRUCIBLE_DOGFOOD_QUIET_OVERRIDE`

**Before**: `info: CRUCIBLE_DOGFOOD_ROOT=…` fired every invocation. CI runs that legitimately set the env var saw the noise every call.

**After**:
- Set `CRUCIBLE_DOGFOOD_QUIET_OVERRIDE=1` to suppress the info line.
- **Only suppresses `info:` severity.** `warn:` and `error:` emit regardless. The opt-in is chosen-noise reduction, never failure masking. Tested explicitly.

## Files

| File | Change |
|---|---|
| `scripts/dogfood-digest.sh` | severity helpers + ~20 call-site conversions + warn rate-limit + QUIET_OVERRIDE wrap + mktemp → exit 3 |
| `scripts/dogfood-digest-render.sh` | severity helpers + ~10 call-site conversions + mktemp → exit 3 |
| `skills/dogfood-digest/SKILL.md` | new Stderr section, 3-way Exit codes, QUIET_OVERRIDE doc |
| `__tests__/integration/test-dogfood-digest.sh` | ISSUE-16 (severity prefixes, exit codes), ISSUE-17 (warn rate-limit), ISSUE-18 (QUIET_OVERRIDE) |

## Test plan

- [x] `bash __tests__/integration/test-dogfood-digest.sh` — ALL PASS (existing 100+ assertions + ~40 new across ISSUE-16/17/18)
- [x] No new shellcheck warnings (existing SC2094/SC2016 info-level warnings predate; new SC2059 from helper functions silenced with directive — `fmt` is internal, not user input)
- [x] Format compatibility: existing tests grep for substrings, not full lines, so they survive the prefix change

## Backward compat note

This PR is an **interface change** for any wrapper that:
- parses stderr by exact-line content (now has `<script>: <severity>: ` prefix)
- branches on exit code 2 expecting it to mean "any failure" (mktemp failures now exit 3)

Wrappers that match on **substrings** (file paths, error keywords) are unaffected. Wrappers that match exit code 0/non-zero are unaffected. Only strict full-line / exact-code matching breaks.

## Out of scope

PR-C (#19, renderer JSON output mode) is the final piece of the PR #7 residual queue; lands separately to keep this PR's interface change well-scoped.