### PR TITLE
feat(digest): renderer --format json structured output (#19)

### DIFF
--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -1599,6 +1599,20 @@ else
     faile "ISSUE-19 frontmatter" "window=$fm_window scope=$fm_scope total=$fm_total"
 fi
 
+# Frontmatter shape: source_counts is an object, generated_at + date are strings.
+# Schema docstring promises these; without an assertion a regression dropping
+# them would only surface as a missing-field bug in callers.
+fm_shape_ok=$(printf '%s' "$json_full" | jq '
+    (.frontmatter | has("source_counts")) and (.frontmatter.source_counts | type == "object")
+    and (.frontmatter | has("generated_at")) and (.frontmatter.generated_at | type == "string")
+    and (.frontmatter | has("date")) and (.frontmatter.date | type == "string")
+')
+if [[ "$fm_shape_ok" == "true" ]]; then
+    pass "ISSUE-19 frontmatter source_counts/generated_at/date present + correct types"
+else
+    faile "ISSUE-19 frontmatter shape" "expected object/string/string, jq=$fm_shape_ok"
+fi
+
 # Three sections in fixed order matching markdown branch.
 section_titles=$(printf '%s' "$json_full" | jq -r '.sections[].title' | tr '\n' '|')
 expected_titles='Threshold Calibration|Protocol Improvements|Promotion Candidates|'
@@ -1627,10 +1641,13 @@ fi
 qa_n=$(printf '%s' "$json_full" | jq '.sections[0].items[] | select(.type=="qa_distribution") | .n')
 qa_promote=$(printf '%s' "$json_full" | jq '.sections[0].items[] | select(.type=="qa_distribution") | .verdicts.promote')
 qa_p50=$(printf '%s' "$json_full" | jq '.sections[0].items[] | select(.type=="qa_distribution") | .p50')
-if [[ "$qa_n" == "3" && "$qa_promote" == "1" && "$qa_p50" == "0.42" ]]; then
-    pass "ISSUE-19 qa_distribution numeric fields (n=3, promote=1, p50=0.42)"
+# p95 with n=3 scores [0.30, 0.42, 0.85] using nearest-rank
+# `floor((n-1)*0.95 + 0.5)` = floor(2.4) = 2 → $s[2] = 0.85.
+qa_p95=$(printf '%s' "$json_full" | jq '.sections[0].items[] | select(.type=="qa_distribution") | .p95')
+if [[ "$qa_n" == "3" && "$qa_promote" == "1" && "$qa_p50" == "0.42" && "$qa_p95" == "0.85" ]]; then
+    pass "ISSUE-19 qa_distribution numeric fields (n=3, promote=1, p50=0.42, p95=0.85)"
 else
-    faile "ISSUE-19 qa numerics" "n=$qa_n promote=$qa_promote p50=$qa_p50"
+    faile "ISSUE-19 qa numerics" "n=$qa_n promote=$qa_promote p50=$qa_p50 p95=$qa_p95"
 fi
 
 # Empty input → items=[] + note string per section, never a missing field
@@ -1641,6 +1658,33 @@ if [[ "$empty_section_count" == "3" ]]; then
     pass "ISSUE-19 empty input: all 3 sections have items=[] and note string"
 else
     faile "ISSUE-19 empty sections" "sections matching items=[] + note: $empty_section_count want 3"
+fi
+
+# Per-discriminator field shape — pin the keys that wrappers may rely on
+# (TEST-1 from PR #26 ce-review). Each item type carries a documented
+# field contract in SKILL.md; if a future refactor renames a key, this
+# block fails before wrappers do.
+shape_ok=$(printf '%s' "$json_full" | jq -e '
+    def has_all(keys): . as $o | all(keys[]; . as $k | $o | has($k));
+    [.sections[].items[]
+        | (
+            (.type == "qa_distribution" and has_all(["n","p50","p95","verdicts","refs"])
+                and (.verdicts | has_all(["promote","retry","reject"]))
+                and ((.refs | type) == "array"))
+         or (.type == "axis_skip_freq" and has_all(["n","histogram","refs"])
+                and ((.histogram | type) == "array")
+                and ((.histogram[0] | has_all(["axis","n"])) // true))
+         or (.type == "pain_group" and has_all(["key","n","cats","sample","refs"]))
+         or (.type == "skip_reason" and has_all(["reason","n","refs"]))
+         or (.type == "promo_group" and has_all(["key","n","cats","sample","refs"]))
+         or (.type == "promotion_gate" and has_all(["n","refs"]))
+          )
+    ] | all
+' >/dev/null && echo true || echo false)
+if [[ "$shape_ok" == "true" ]]; then
+    pass "ISSUE-19 per-discriminator field shape contracts (all 6 types)"
+else
+    faile "ISSUE-19 item shape" "one or more items missing documented required fields"
 fi
 
 # refs preserved for back-reference auditability.
@@ -1678,6 +1722,21 @@ if [[ "$dup_fmt_rc" == "2" ]] && printf '%s' "$dup_fmt_err" | grep -F -q -- 'ren
     pass "ISSUE-19 duplicate --format → exit 2"
 else
     faile "ISSUE-19 dup format" "rc=$dup_fmt_rc stderr=$(tr '\n' '|' <<<"$dup_fmt_err")"
+fi
+
+# Missing-value error path: `--format` at end-of-args (shift 2 fails) must
+# exit 2 with the standard `--format requires a value` message. Tests cover
+# bad value and duplicate but not missing-value, leaving one branch of the
+# arg validator silently uncovered.
+set +e
+miss_fmt_err=$(echo "" | "$renderer" --window 7d --format 2>&1 >/dev/null)
+echo "" | "$renderer" --window 7d --format >/dev/null 2>/dev/null
+miss_fmt_rc=$?
+set -e
+if [[ "$miss_fmt_rc" == "2" ]] && printf '%s' "$miss_fmt_err" | grep -F -q -- 'render: error: --format requires a value'; then
+    pass "ISSUE-19 --format with no value → exit 2"
+else
+    faile "ISSUE-19 missing format value" "rc=$miss_fmt_rc stderr=$(tr '\n' '|' <<<"$miss_fmt_err")"
 fi
 
 # Default markdown unchanged — backward compat invariant. The first

--- a/__tests__/integration/test-dogfood-digest.sh
+++ b/__tests__/integration/test-dogfood-digest.sh
@@ -1551,11 +1551,173 @@ fi
 rm -rf "$warn_quiet_proj"
 
 # ----------------------------------------------------------------------------
+# Issue #19 — renderer --format json structured output mode
+# Markdown is great for humans but bad for agents — they regex it,
+# miscount blank lines, drift on Korean copy. JSON gives a stable shape
+# (schema_version "1") with `type`-discriminated items so wrappers parse
+# instead of regex.
+# ----------------------------------------------------------------------------
+
+printf 'ISSUE-19: renderer --format json structured output\n'
+
+# Fixture: enough rows to trigger every section + every item type.
+issue19_input=$(cat <<'EOF'
+{"_source_path":"a.jsonl","_line":1,"ts":"2026-01-01T00:00:00Z","type":"qa_judge","score":0.85,"verdict":"promote"}
+{"_source_path":"a.jsonl","_line":2,"ts":"2026-01-02T00:00:00Z","type":"qa_judge","score":0.42,"verdict":"retry"}
+{"_source_path":"a.jsonl","_line":3,"ts":"2026-01-03T00:00:00Z","type":"qa_judge","score":0.30,"verdict":"reject"}
+{"_source_path":"a.jsonl","_line":4,"ts":"2026-01-04T00:00:00Z","type":"axis_skip","axis":5,"reason":"timing"}
+{"_source_path":"a.jsonl","_line":5,"ts":"2026-01-05T00:00:00Z","type":"axis_skip","axis":5,"reason":"timing"}
+{"_source_path":"a.jsonl","_line":6,"ts":"2026-01-06T00:00:00Z","type":"axis_skip","axis":3,"reason":"scope"}
+{"_source_path":"a.jsonl","_line":7,"ts":"2026-01-07T00:00:00Z","type":"note","category":"pain","text":"/crucible:plan flow stuck"}
+{"_source_path":"a.jsonl","_line":8,"ts":"2026-01-08T00:00:00Z","type":"note","category":"good","text":"/crucible:verify nice"}
+{"_source_path":"a.jsonl","_line":9,"ts":"2026-01-09T00:00:00Z","type":"promotion_gate","response":"y"}
+{"_source_path":"a.jsonl","_line":10,"ts":"2026-01-10T00:00:00Z","type":"promotion_gate","response":"y"}
+EOF
+)
+
+# Full populated emission — single line, valid JSON, schema_version "1".
+json_full=$(printf '%s\n' "$issue19_input" | "$renderer" --window 7d --scope local --threshold-n 1 --format json 2>/dev/null)
+if printf '%s' "$json_full" | jq -e . >/dev/null 2>&1; then
+    pass "ISSUE-19 emits valid JSON"
+else
+    faile "ISSUE-19 valid json" "output not parseable: $(tr '\n' '|' <<<"$json_full")"
+fi
+
+if [[ "$(printf '%s' "$json_full" | jq -r '.schema_version')" == "1" ]]; then
+    pass "ISSUE-19 schema_version is \"1\""
+else
+    faile "ISSUE-19 schema_version" "got $(printf '%s' "$json_full" | jq -r '.schema_version')"
+fi
+
+# Frontmatter parity with markdown: window/scope/total_events/source_counts/date.
+fm_window=$(printf '%s' "$json_full" | jq -r '.frontmatter.window')
+fm_scope=$(printf '%s' "$json_full" | jq -r '.frontmatter.scope')
+fm_total=$(printf '%s' "$json_full" | jq -r '.frontmatter.total_events')
+if [[ "$fm_window" == "7d" && "$fm_scope" == "local" && "$fm_total" == "10" ]]; then
+    pass "ISSUE-19 frontmatter window/scope/total_events"
+else
+    faile "ISSUE-19 frontmatter" "window=$fm_window scope=$fm_scope total=$fm_total"
+fi
+
+# Three sections in fixed order matching markdown branch.
+section_titles=$(printf '%s' "$json_full" | jq -r '.sections[].title' | tr '\n' '|')
+expected_titles='Threshold Calibration|Protocol Improvements|Promotion Candidates|'
+if [[ "$section_titles" == "$expected_titles" ]]; then
+    pass "ISSUE-19 three sections in fixed order"
+else
+    faile "ISSUE-19 section titles" "got: $section_titles want: $expected_titles"
+fi
+
+# Item type discriminators must populate from the fixture.
+have_qa=$(printf '%s' "$json_full" | jq '[.sections[0].items[] | select(.type=="qa_distribution")] | length')
+have_skip_freq=$(printf '%s' "$json_full" | jq '[.sections[0].items[] | select(.type=="axis_skip_freq")] | length')
+have_pain=$(printf '%s' "$json_full" | jq '[.sections[1].items[] | select(.type=="pain_group")] | length')
+have_skip_reason=$(printf '%s' "$json_full" | jq '[.sections[1].items[] | select(.type=="skip_reason")] | length')
+have_promo=$(printf '%s' "$json_full" | jq '[.sections[2].items[] | select(.type=="promo_group")] | length')
+have_gate=$(printf '%s' "$json_full" | jq '[.sections[2].items[] | select(.type=="promotion_gate")] | length')
+if [[ "$have_qa" -ge 1 && "$have_skip_freq" -ge 1 && "$have_pain" -ge 1 && \
+      "$have_skip_reason" -ge 1 && "$have_promo" -ge 1 && "$have_gate" -ge 1 ]]; then
+    pass "ISSUE-19 all 6 item types present"
+else
+    faile "ISSUE-19 item types" "qa=$have_qa skip_freq=$have_skip_freq pain=$have_pain skip_reason=$have_skip_reason promo=$have_promo gate=$have_gate"
+fi
+
+# qa_distribution numeric fields — agent should be able to do math without
+# pulling them from regex'd Markdown.
+qa_n=$(printf '%s' "$json_full" | jq '.sections[0].items[] | select(.type=="qa_distribution") | .n')
+qa_promote=$(printf '%s' "$json_full" | jq '.sections[0].items[] | select(.type=="qa_distribution") | .verdicts.promote')
+qa_p50=$(printf '%s' "$json_full" | jq '.sections[0].items[] | select(.type=="qa_distribution") | .p50')
+if [[ "$qa_n" == "3" && "$qa_promote" == "1" && "$qa_p50" == "0.42" ]]; then
+    pass "ISSUE-19 qa_distribution numeric fields (n=3, promote=1, p50=0.42)"
+else
+    faile "ISSUE-19 qa numerics" "n=$qa_n promote=$qa_promote p50=$qa_p50"
+fi
+
+# Empty input → items=[] + note string per section, never a missing field
+# that wrappers would have to defensive-code around.
+json_empty=$(echo "" | "$renderer" --window 7d --scope both --threshold-n 3 --format json 2>/dev/null)
+empty_section_count=$(printf '%s' "$json_empty" | jq '[.sections[] | select(.items == [] and (.note | type == "string"))] | length')
+if [[ "$empty_section_count" == "3" ]]; then
+    pass "ISSUE-19 empty input: all 3 sections have items=[] and note string"
+else
+    faile "ISSUE-19 empty sections" "sections matching items=[] + note: $empty_section_count want 3"
+fi
+
+# refs preserved for back-reference auditability.
+refs_count=$(printf '%s' "$json_full" | jq '[.sections[].items[] | .refs[]?] | length')
+if [[ "$refs_count" -ge 6 ]]; then
+    pass "ISSUE-19 refs[] preserved across items (n=$refs_count)"
+else
+    faile "ISSUE-19 refs preservation" "got $refs_count refs total, want >= 6"
+fi
+
+# --format jason → exit 2 with severity prefix. Strict whitelist —
+# "default to markdown" would have masked typos. Wrap with set +e because
+# expected-failure runs would otherwise abort the test under set -e.
+set +e
+bad_fmt_err=$(echo "" | "$renderer" --window 7d --format jason 2>&1 >/dev/null)
+bad_fmt_rc_first=$?
+echo "" | "$renderer" --window 7d --format jason >/dev/null 2>/dev/null
+bad_fmt_rc=$?
+set -e
+# Pipeline rc may not equal renderer rc when stdout sink is /dev/null — use
+# the second invocation's $? as the authoritative renderer exit code.
+if [[ "$bad_fmt_rc" == "2" ]] && printf '%s' "$bad_fmt_err" | grep -F -q -- 'render: error: --format must be markdown or json'; then
+    pass "ISSUE-19 --format jason → exit 2 with whitelist error"
+else
+    faile "ISSUE-19 bad format" "rc=$bad_fmt_rc (pipeline rc=$bad_fmt_rc_first) stderr=$(tr '\n' '|' <<<"$bad_fmt_err")"
+fi
+
+# Duplicate --format → exit 2 (mirrors the dedup pattern from issue #9).
+set +e
+dup_fmt_err=$(echo "" | "$renderer" --window 7d --format json --format markdown 2>&1 >/dev/null)
+echo "" | "$renderer" --window 7d --format json --format markdown >/dev/null 2>/dev/null
+dup_fmt_rc=$?
+set -e
+if [[ "$dup_fmt_rc" == "2" ]] && printf '%s' "$dup_fmt_err" | grep -F -q -- 'render: error: --format passed more than once'; then
+    pass "ISSUE-19 duplicate --format → exit 2"
+else
+    faile "ISSUE-19 dup format" "rc=$dup_fmt_rc stderr=$(tr '\n' '|' <<<"$dup_fmt_err")"
+fi
+
+# Default markdown unchanged — backward compat invariant. The first
+# stdout line of a no-flag run must still be the YAML frontmatter
+# fence, not a JSON brace. (The biggest regression a JSON branch can
+# cause is silently flipping default output.) Capture full output and
+# slice in bash to avoid SIGPIPE under `set -o pipefail` from `| head -1`.
+md_default_full=$(echo "" | "$renderer" --window 7d --threshold-n 3 2>/dev/null)
+md_default_first="${md_default_full%%$'\n'*}"
+if [[ "$md_default_first" == "---" ]]; then
+    pass "ISSUE-19 default (no --format) still emits Markdown frontmatter"
+else
+    faile "ISSUE-19 default markdown" "first line: $md_default_first — JSON branch may have flipped default"
+fi
+
+# --format markdown explicit → identical first line.
+md_explicit_full=$(echo "" | "$renderer" --window 7d --threshold-n 3 --format markdown 2>/dev/null)
+md_explicit_first="${md_explicit_full%%$'\n'*}"
+if [[ "$md_explicit_first" == "---" ]]; then
+    pass "ISSUE-19 explicit --format markdown emits Markdown"
+else
+    faile "ISSUE-19 explicit markdown" "first line: $md_explicit_first"
+fi
+
+# print_help mentions --format. Agents reading --help to discover
+# capabilities will miss the JSON surface entirely otherwise.
+help_out=$("$renderer" --help 2>&1)
+if printf '%s' "$help_out" | grep -F -q -- '--format' && \
+   printf '%s' "$help_out" | grep -F -q -- 'json'; then
+    pass "ISSUE-19 --help mentions --format and json"
+else
+    faile "ISSUE-19 help" "help text missing --format/json: $(tr '\n' '|' <<<"$help_out" | head -c 400)"
+fi
+
+# ----------------------------------------------------------------------------
 # Summary
 # ----------------------------------------------------------------------------
 
 if [[ "$fail" -eq 0 ]]; then
-    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-9/14/15/16/17/18 + 14-mirror + help-constraints)\n'
+    printf '\ntest-dogfood-digest: ALL PASS (SC-1~7 + recursion filter + ADV-003/006/007/008 + issue-9/14/15/16/17/18/19 + 14-mirror + help-constraints)\n'
     exit 0
 else
     printf '\ntest-dogfood-digest: FAIL\n'

--- a/docs/skills/dogfood-digest.ko.md
+++ b/docs/skills/dogfood-digest.ko.md
@@ -12,6 +12,8 @@
 
 입력: 로컬 `.claude/dogfood/log.jsonl` 과 글로벌 mirror `~/.claude/dogfood/crucible/{slug}-{hash}/log.jsonl` 의 조합. `--last N`(기본 10) / `--since DATE|Nd` / `--all` 중 하나로 window, `--scope local|global|both`(기본 both) 로 scope 를 선택합니다. 출력: `.claude/plans/` 안의 Markdown 1건 — 그 외 추적 파일은 절대 건드리지 않습니다.
 
+출력 형식은 `--format markdown|json`(기본 markdown) 로 선택. `json` 분기는 `schema_version: "1"`(JSON 문자열 — `.schema_version == "1"` 로 비교) 이 박힌 단일 객체를 stdout 으로 emit, 같은 3섹션 구조를 유지해 에이전트 호출자가 Markdown 정규식 대신 jq 로 파싱합니다. 각 item 은 `type` 디스크리미네이터를 들고 있어 wrapper 가 위치 인덱스 대신 type 으로 분기합니다. 디스크리미네이터: `qa_distribution`, `axis_skip_freq`, `pain_group`, `skip_reason`, `promo_group`, `promotion_gate`.
+
 모든 JSONL 라인은 메모리 상에서 `_source_path` + `_line`(1-based) 이 주입되므로 리포트의 각 제안이 원본 이벤트를 인용할 수 있습니다. 리포트는 위에서 아래로 읽도록 설계돼 있습니다:
 
 | 섹션 | 소스 이벤트 | 휴리스틱 |

--- a/docs/skills/dogfood-digest.md
+++ b/docs/skills/dogfood-digest.md
@@ -12,6 +12,8 @@ English · [한국어](./dogfood-digest.ko.md)
 
 Input: any combination of local `.claude/dogfood/log.jsonl` and global mirror `~/.claude/dogfood/crucible/{slug}-{hash}/log.jsonl`, filtered by one of `--last N` (default 10), `--since DATE|Nd`, or `--all`, and scoped via `--scope local|global|both` (default both). Output: a single Markdown file saved to `.claude/plans/`, never overwriting any other tracked file.
 
+Output format is selectable via `--format markdown|json` (default markdown). The JSON branch emits a single schema-versioned object on stdout (`schema_version: "1"` — JSON string, compare with `.schema_version == "1"`) with the same three fixed sections, so agent consumers parse with `jq` instead of regexing the Markdown report. Each item carries a `type` discriminator so wrappers switch on `type` rather than positional index. Discriminators: `qa_distribution`, `axis_skip_freq`, `pain_group`, `skip_reason`, `promo_group`, `promotion_gate`.
+
 Every emitted JSONL line is augmented in-memory with `_source_path` and `_line` (1-based) so each suggestion in the report cites the originating event. The report is designed to read top-down:
 
 | Section | Source events | Heuristic |

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -74,6 +74,11 @@ Flags:
                       callers parse it with jq instead of regexing Markdown
                       sections (issue #19). Schema:
                         {schema_version, frontmatter, sections:[{title,items[],note?}]}
+                      schema_version is a JSON STRING ("1", not 1) — compare with
+                      `.schema_version == "1"`. Item types (.type discriminator):
+                      qa_distribution, axis_skip_freq, pain_group, skip_reason,
+                      promo_group, promotion_gate. Per-type field shape lives in
+                      skills/dogfood-digest/SKILL.md.
   -h | --help         print usage
 
 Constraints:
@@ -327,7 +332,7 @@ if [[ "$output_format" == "json" ]]; then
     else
         s1_items='[]'
         if [[ "$qa_count" -ge "$threshold_n" ]]; then
-            s1_qa_item=$(printf '%s' "$qa_json" | jq -c --argjson tn "$threshold_n" '
+            s1_qa_item=$(printf '%s' "$qa_json" | jq -c '
                 . as $rows
                 | ([.[] | select(.verdict=="promote")] | length) as $promote
                 | ([.[] | select(.verdict=="retry")] | length) as $retry

--- a/scripts/dogfood-digest-render.sh
+++ b/scripts/dogfood-digest-render.sh
@@ -56,10 +56,10 @@ info() { local fmt="$1"; shift; printf "render: info: ${fmt}\\n" "$@" >&2; }
 
 print_help() {
     cat <<'USAGE'
-Usage: dogfood-digest-render.sh --window LABEL [--scope SCOPE] [--threshold-n N]
+Usage: dogfood-digest-render.sh --window LABEL [--scope SCOPE] [--threshold-n N] [--format FORMAT]
 
-Reads filtered dogfood JSONL on stdin and emits a 3-section Markdown proposal
-report on stdout.
+Reads filtered dogfood JSONL on stdin and emits a 3-section proposal report
+on stdout (Markdown by default; structured JSON when --format json).
 
 Flags:
   --window LABEL      window label used in frontmatter + filename (required)
@@ -69,10 +69,16 @@ Flags:
   --threshold-n N     positive integer in [1, 1000000]; minimum observation
                       count for threshold suggestions (default: 3; lower values
                       mean quieter logs still emit)
+  --format FORMAT     markdown | json (default markdown). `json` emits a single
+                      structured object on stdout with schema_version "1" — agent
+                      callers parse it with jq instead of regexing Markdown
+                      sections (issue #19). Schema:
+                        {schema_version, frontmatter, sections:[{title,items[],note?}]}
   -h | --help         print usage
 
 Constraints:
   --threshold-n is a positive integer in [1, 1000000]; out-of-range → exit 2.
+  --format must be one of {markdown, json}; typos like `jason` → exit 2.
   Each named flag may appear at most once (duplicate → exit 2).
 
 Stderr severity tagging:
@@ -94,6 +100,7 @@ USAGE
 window_label=""
 scope_label="both"
 threshold_n=3
+output_format="markdown"
 
 # Track per-flag occurrence so `--threshold-n 1 --threshold-n 99` no longer
 # silently overwrites the first value (issue #9). Mirrors the aggregator's
@@ -101,6 +108,7 @@ threshold_n=3
 saw_window=0
 saw_scope=0
 saw_threshold_n=0
+saw_format=0
 
 reject_duplicate() {
     err '%s passed more than once — pass it at most once' "$1"
@@ -129,6 +137,12 @@ while [[ $# -gt 0 ]]; do
             saw_threshold_n=1
             threshold_n="${2:-}"
             shift 2 || { err '--threshold-n requires a value'; exit 2; }
+            ;;
+        --format)
+            if [[ "$saw_format" -eq 1 ]]; then reject_duplicate --format; fi
+            saw_format=1
+            output_format="${2:-}"
+            shift 2 || { err '--format requires a value'; exit 2; }
             ;;
         -h|--help)
             print_help
@@ -169,6 +183,18 @@ case "$scope_label" in
     local|global|both) ;;
     *)
         err '--scope must be local, global, or both (got: %s)' "$scope_label"
+        exit 2
+        ;;
+esac
+
+# Validate --format. Default `markdown` keeps existing wrappers working
+# unchanged; `json` is the new agent-targeted surface (issue #19). Strict
+# whitelist so a typo like `--format jason` errors loudly instead of falling
+# through to either branch.
+case "$output_format" in
+    markdown|json) ;;
+    *)
+        err '--format must be markdown or json (got: %s)' "$output_format"
         exit 2
         ;;
 esac
@@ -264,9 +290,192 @@ source_counts_json="$(jq -sc '[.[]._source_path] | group_by(.) | map({(.[0]): le
 # ----- frontmatter -----------------------------------------------------------
 
 today="$(date -u +%Y-%m-%d)"
+generated_at="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+# ----- JSON output branch (issue #19) ---------------------------------------
+#
+# When `--format json` is set, emit a single structured JSON object on stdout
+# instead of the human-targeted Markdown report. Same input, same aggregates,
+# different shape — agent callers parse this with jq instead of regexing
+# Markdown sections.
+#
+# Schema (schema_version "1"):
+#   {
+#     "schema_version": "1",
+#     "frontmatter": { generated_at, window, scope, total_events,
+#                      source_counts, date },
+#     "sections": [ { "title", "items": [...], "note"? } x3 ]
+#   }
+#
+# Section order is fixed: Threshold Calibration, Protocol Improvements,
+# Promotion Candidates — mirrors the Markdown layout. Empty sections carry
+# `items: []` and a `note` string describing the no-signal condition; the
+# Markdown branch's `> no signal in window` line. Item objects carry a
+# `type` discriminator (qa_distribution, axis_skip_freq, pain_group,
+# skip_reason, promo_group, promotion_gate) so wrappers can switch on type
+# rather than positional index.
+#
+# All aggregate values reuse the *_json variables computed above so the
+# JSON and Markdown branches stay in lock-step on the same dataset; any
+# future fix to ingestion / filtering applies to both branches uniformly.
+if [[ "$output_format" == "json" ]]; then
+    # ---- Section 1: Threshold Calibration ----
+    if [[ "$qa_count" -lt "$threshold_n" && "$skip_count" -lt "$threshold_n" ]]; then
+        section1=$(jq -nc --argjson qa "$qa_count" --argjson sk "$skip_count" --argjson tn "$threshold_n" \
+            '{title:"Threshold Calibration", items:[],
+              note:"no signal in window (qa_judge n=\($qa), axis_skip n=\($sk), threshold-n=\($tn))"}')
+    else
+        s1_items='[]'
+        if [[ "$qa_count" -ge "$threshold_n" ]]; then
+            s1_qa_item=$(printf '%s' "$qa_json" | jq -c --argjson tn "$threshold_n" '
+                . as $rows
+                | ([.[] | select(.verdict=="promote")] | length) as $promote
+                | ([.[] | select(.verdict=="retry")] | length) as $retry
+                | ([.[] | select(.verdict=="reject")] | length) as $reject
+                | (if length == 0 then null
+                   else ([.[].score] | sort) as $s
+                       | ($s | length) as $n
+                       | $s[(($n - 1) / 2) | floor]
+                   end) as $p50
+                | (if length == 0 then null
+                   else ([.[].score] | sort) as $s
+                       | ($s | length) as $n
+                       | ((($n - 1) * 0.95 + 0.5) | floor) as $i
+                       | $s[if $i >= $n then $n - 1 else $i end]
+                   end) as $p95
+                | {type:"qa_distribution", n:length, p50:$p50, p95:$p95,
+                   verdicts:{promote:$promote, retry:$retry, reject:$reject},
+                   refs:[$rows[] | "\(._source_path):\(._line)"][0:3]}
+            ')
+            s1_items=$(jq -nc --argjson item "$s1_qa_item" '[$item]')
+        fi
+        if [[ "$skip_count" -ge "$threshold_n" ]]; then
+            s1_skip_item=$(printf '%s' "$skip_json" | jq -c '
+                . as $rows
+                | {type:"axis_skip_freq", n:length,
+                   histogram:([.[].axis] | group_by(.) | map({axis:.[0], n:length})),
+                   refs:[$rows[] | "\(._source_path):\(._line)"][0:3]}
+            ')
+            s1_items=$(printf '%s' "$s1_items" | jq -c --argjson item "$s1_skip_item" '. + [$item]')
+        fi
+        section1=$(jq -nc --argjson items "$s1_items" \
+            '{title:"Threshold Calibration", items:$items}')
+    fi
+
+    # ---- Section 2: Protocol Improvements ----
+    if [[ "$pain_count" -eq 0 && "$skip_count" -lt 2 ]]; then
+        section2=$(jq -nc '{title:"Protocol Improvements", items:[], note:"no signal in window"}')
+    else
+        s2_pain_items='[]'
+        s2_skip_items='[]'
+        if [[ "$pain_count" -gt 0 ]]; then
+            s2_pain_items=$(printf '%s' "$pain_json" | jq -c '
+                map({
+                    key: ((.text // "") | capture("(?<k>/crucible:[a-z0-9_-]+)"; "i").k // "general"),
+                    category: .category,
+                    text: (.text // ""),
+                    src: "\(._source_path):\(._line)"
+                })
+                | group_by(.key)
+                | map({
+                    type:"pain_group",
+                    key:.[0].key,
+                    n:length,
+                    cats:([.[].category] | unique | join("+")),
+                    sample:(.[0].text),
+                    refs:([.[].src][0:3])
+                })
+                | sort_by(-.n)
+                | .[0:5]
+            ')
+        fi
+        if [[ "$skip_count" -ge 2 ]]; then
+            s2_skip_items=$(printf '%s' "$skip_json" | jq -c '
+                [.[] | select(.reason != null) | {reason:.reason, src:"\(._source_path):\(._line)"}]
+                | group_by(.reason)
+                | map({type:"skip_reason", reason:.[0].reason, n:length, refs:([.[].src][0:3])})
+                | map(select(.n >= 2))
+                | .[0:3]
+            ')
+        fi
+        s2_items=$(jq -nc --argjson a "$s2_pain_items" --argjson b "$s2_skip_items" '$a + $b')
+        if [[ "$(printf '%s' "$s2_items" | jq 'length')" -eq 0 ]]; then
+            section2=$(jq -nc '{title:"Protocol Improvements", items:[], note:"no signal in window"}')
+        else
+            section2=$(jq -nc --argjson items "$s2_items" '{title:"Protocol Improvements", items:$items}')
+        fi
+    fi
+
+    # ---- Section 3: Promotion Candidates ----
+    if [[ "$promo_notes_count" -eq 0 && "$gate_count" -lt 2 ]]; then
+        section3=$(jq -nc '{title:"Promotion Candidates", items:[], note:"no signal in window"}')
+    else
+        s3_note_items='[]'
+        s3_gate_items='[]'
+        if [[ "$promo_notes_count" -gt 0 ]]; then
+            s3_note_items=$(printf '%s' "$promo_notes_json" | jq -c '
+                map({
+                    key: ((.text // "") | capture("(?<k>/crucible:[a-z0-9_-]+)"; "i").k // "general"),
+                    category: .category,
+                    text: (.text // ""),
+                    src: "\(._source_path):\(._line)"
+                })
+                | group_by(.key)
+                | map({
+                    type:"promo_group",
+                    key:.[0].key,
+                    n:length,
+                    cats:([.[].category] | unique | join("+")),
+                    sample:(.[0].text),
+                    refs:([.[].src][0:3])
+                })
+                | map(select(.n >= 1))
+                | sort_by(-.n)
+                | .[0:5]
+            ')
+        fi
+        if [[ "$gate_count" -ge 2 ]]; then
+            s3_gate_items=$(printf '%s' "$gate_json" | jq -c '
+                . as $rows
+                | [{type:"promotion_gate", n:length,
+                    refs:[$rows[] | "\(._source_path):\(._line)"][0:3]}]
+            ')
+        fi
+        s3_items=$(jq -nc --argjson a "$s3_note_items" --argjson b "$s3_gate_items" '$a + $b')
+        if [[ "$(printf '%s' "$s3_items" | jq 'length')" -eq 0 ]]; then
+            section3=$(jq -nc '{title:"Promotion Candidates", items:[], note:"no signal in window"}')
+        else
+            section3=$(jq -nc --argjson items "$s3_items" '{title:"Promotion Candidates", items:$items}')
+        fi
+    fi
+
+    jq -nc \
+        --arg generated_at "$generated_at" \
+        --arg window "$window_label" \
+        --arg scope "$scope_label" \
+        --argjson total_events "$total_events" \
+        --argjson source_counts "$source_counts_json" \
+        --arg date "$today" \
+        --argjson section1 "$section1" \
+        --argjson section2 "$section2" \
+        --argjson section3 "$section3" \
+        '{
+            schema_version: "1",
+            frontmatter: {
+                generated_at: $generated_at,
+                window: $window,
+                scope: $scope,
+                total_events: $total_events,
+                source_counts: $source_counts,
+                date: $date
+            },
+            sections: [$section1, $section2, $section3]
+        }'
+    exit 0
+fi
 
 printf -- '---\n'
-printf 'generated_at: "%s"\n' "$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+printf 'generated_at: "%s"\n' "$generated_at"
 printf 'window: "%s"\n' "$window_label"
 printf 'scope: "%s"\n' "$scope_label"
 printf 'total_events: %s\n' "$total_events"

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -39,6 +39,15 @@ input: |
                        (기본 3). 양의 정수, 최대 1_000_000.
                        범위 밖 / 비숫자는 exit 2 (PR #24 ce-review P1 — same
                        arithmetic-overflow surface as aggregator's --last).
+    --format markdown|json   기본 markdown. `json` 은 단일 구조화 객체를
+                       stdout 으로 emit (issue #19) — 에이전트 호출자가 jq 로
+                       파싱 가능. 알 수 없는 값(`jason` 등)은 exit 2.
+                       스키마: `{schema_version, frontmatter, sections[]}`,
+                       각 section 은 `{title, items[], note?}`. 각 item 은
+                       `type` discriminator (qa_distribution · axis_skip_freq ·
+                       pain_group · skip_reason · promo_group · promotion_gate)
+                       를 들고 있어 wrapper 가 위치 인덱스 대신 type 으로
+                       분기한다.
 
   입력 소스 (aggregator 가 resolve, renderer 는 stdin 만 읽음):
     로컬  `${CRUCIBLE_DOGFOOD_ROOT:-${PROJECT_ROOT}}/.claude/dogfood/log.jsonl`
@@ -48,6 +57,11 @@ output: |
   {window} ∈ { last{N}, since-{YYYY-MM-DD|Nd}, all }
   프론트매터(generated_at · window · scope · total_events · source_counts) + Markdown 본문 3섹션
   (Threshold Calibration · Protocol Improvements · Promotion Candidates).
+
+  Renderer `--format json` (issue #19): `.md` 대신 단일 JSON 객체를 stdout 으로
+  emit. 에이전트 호출자는 jq 로 파싱한다. 호출자가 redirect 하는 경로의
+  관례는 `.claude/plans/YYYY-MM-DD-dogfood-digest-{window}.json` 이지만
+  스크립트는 파일을 직접 쓰지 않는다 (Phase 4 와 동일).
 
   Stderr (issue #16): 모든 라인이 `<script>: <severity>: <msg>` 형식.
     severity ∈ {info, warn, error}. 에이전트가 자유 텍스트 파싱 없이

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -63,6 +63,26 @@ output: |
   관례는 `.claude/plans/YYYY-MM-DD-dogfood-digest-{window}.json` 이지만
   스크립트는 파일을 직접 쓰지 않는다 (Phase 4 와 동일).
 
+  schema_version 은 **JSON STRING** (`"1"`, 숫자 1 아님). 호출자는 반드시
+  `.schema_version == "1"` 로 비교해야 하며, 정수 비교 (`== 1`) 는 미래
+  bump 시점에 silent miss 한다.
+
+  item type 별 필드 contract — wrapper 가 type 으로 분기 후 안전하게
+  pin 할 수 있는 키 집합 (이 contract 를 깨는 변경은 schema_version bump
+  를 요구한다):
+
+  | type | required fields | optional fields |
+  |------|-----------------|-----------------|
+  | qa_distribution | n (int), p50 (number\|null), p95 (number\|null), verdicts.{promote,retry,reject} (int), refs (array of "path:line" strings) | — |
+  | axis_skip_freq | n (int), histogram (array of {axis,n}), refs (array) | — |
+  | pain_group | type, key, n, cats (string), sample (string), refs (array) | — |
+  | skip_reason | type, reason (string), n, refs (array) | — |
+  | promo_group | type, key, n, cats (string), sample (string), refs (array) | — |
+  | promotion_gate | type, n, refs (array) | — |
+
+  refs 는 현재 `"path:line"` 문자열 배열로 직렬화된다. 향후 객체 배열
+  (`[{path,line}]`) 로 옮길 가능성은 schema_version bump 의 후보.
+
   Stderr (issue #16): 모든 라인이 `<script>: <severity>: <msg>` 형식.
     severity ∈ {info, warn, error}. 에이전트가 자유 텍스트 파싱 없이
     severity 키워드만으로 분류 가능. 파일별 malformed-row warn 은 5건까지

--- a/skills/dogfood-digest/SKILL.md
+++ b/skills/dogfood-digest/SKILL.md
@@ -198,6 +198,23 @@ Do **not** use when:
 
 **출력**: Markdown 문자열 (stdout).
 
+`--format json` 을 사용하는 경우 stdout 은 단일 JSON 객체다. 최상위 구조는 `{schema_version, frontmatter, sections[]}` 이고, 섹션 순서는 Threshold Calibration → Protocol Improvements → Promotion Candidates 로 고정된다. 각 section 은 `{title, items[]}` 이며, `note` 필드는 **`items` 가 비어 있을 때만 반드시 존재하고, `items` 가 1건 이상이면 반드시 부재한다** — 이 불변식은 `__tests__/integration/test-dogfood-digest.sh` ISSUE-19 블록이 강제하고 있다.
+
+> **`schema_version` 비교 주의**: `schema_version` 은 JSON **STRING** 이다 (`"1"`, 숫자 `1` 아님). 반드시 `.schema_version == "1"` (문자열 비교) 로 확인해야 하며, `.schema_version == 1` (정수 비교) 는 항상 `false` 를 반환해 wrapper 가 잘못된 fallback 경로로 흘러간다.
+
+각 item 은 `type` discriminator 를 들고 있다. 아래는 type 별 보장 필드 목록이다 (이 contract 를 깨는 변경은 `schema_version` bump 를 요구한다):
+
+| type | 보장 필드 |
+|------|-----------|
+| `qa_distribution` | `n` (int) · `p50` (number\|null) · `p95` (number\|null) · `verdicts.promote` / `.retry` / `.reject` (int) · `refs` (array of `"path:line"`) |
+| `axis_skip_freq` | `n` (int) · `histogram` (array of `{axis, n}`) · `refs` |
+| `pain_group` | `key` (string) · `n` (int) · `cats` (string) · `sample` (string) · `refs` |
+| `skip_reason` | `reason` (string) · `n` (int) · `refs` |
+| `promo_group` | `key` (string) · `n` (int) · `cats` (string) · `sample` (string) · `refs` |
+| `promotion_gate` | `n` (int) · `refs` |
+
+`refs` 는 `"<source_path>:<line>"` 문자열 배열로 직렬화된다 (최대 3건). 향후 객체 배열(`[{path,line}]`) 로 변경될 경우 `schema_version` bump 대상이다.
+
 **실패 시 fallback**: 섹션 휴리스틱이 모든 관측수 하한 미만 → 빈 섹션 대신 명시적 안내. jq 파이프 실패 → stderr 경고 후 섹션을 `> no signal in window` 로 채워 리포트 완결.
 
 ---


### PR DESCRIPTION
## Summary

Closes #19. Adds a `--format json` branch to `scripts/dogfood-digest-render.sh` so agent callers consume a structured JSON object instead of regex'ing the Markdown report.

- Schema (`schema_version: "1"`): `{ frontmatter, sections: [{ title, items[], note? } × 3] }`.
- Section order is fixed: Threshold Calibration · Protocol Improvements · Promotion Candidates (mirrors the Markdown layout).
- Items carry a `type` discriminator: `qa_distribution`, `axis_skip_freq`, `pain_group`, `skip_reason`, `promo_group`, `promotion_gate`.
- Empty sections emit `items: []` + a `note` string — no missing-field defensive coding required of callers.
- Default stays Markdown — `--format jason` exits 2 with the standard `render: error:` prefix; duplicate `--format` exits 2 via the same dedup pattern as #9.
- JSON branch reuses the same `_json` intermediates as the Markdown branch so future ingestion/filter fixes apply uniformly.

## Test plan

- [x] `bash __tests__/integration/test-dogfood-digest.sh` — ALL PASS (issue-9/14/15/16/17/18/19 + 14-mirror + help-constraints)
- [x] ISSUE-19 block: 12 assertions covering valid JSON shape, schema_version, frontmatter parity, fixed section order, all 6 item types, qa numeric fields, empty-section `items: [] + note`, refs preservation, `--format jason` rejection, duplicate `--format` rejection, default-markdown invariant, `--format markdown` explicit, `--help` mentions `--format`/`json`.
- [x] Smoke test on real fixture confirmed (10-row input → JSON output validates with `jq -e .`, all 6 item types present).
- [x] shellcheck clean on new code (the 2 SC2016 infos are pre-existing backtick literals in Korean strings).

## Out of scope

- Tooling that writes the JSON to disk on the caller's behalf (Phase 4 of the skill remains caller-owned, same as Markdown).
- Schema evolution path beyond v1 — schema_version is included so future bumps stay non-breaking.